### PR TITLE
Hack around not being able to find names for consts

### DIFF
--- a/autowrap/PXDParser.py
+++ b/autowrap/PXDParser.py
@@ -231,7 +231,6 @@ class CTypeDefDecl(BaseDecl):
     def parseTree(cls, node, lines, pxd_path):
         decl = node.declarator
         new_name = _traverse_for_name(decl, 'base')
-
         type_ = _extract_type(node.base_type, node.declarator)
         annotations = parse_line_annotations(node, lines)
         return cls(new_name, type_, annotations, pxd_path)


### PR DESCRIPTION
There's no doubt a better way to handle this (I've only barely read through autowrap), but this quick traversal hack has worked for me so far. I'm unsure of the possible effects of doing this.

``` c
const char * http_errno_name(http_errno err);
ctypedef int (*http_data_cb)(http_parser*, const char *at, size_t length);
```

Without this, consts like the above raise an AttributeError as there's no name attribute on the parent object we're trying to retrieve the name of.
