### PR TITLE
[FEATURE] Use lstrip in multiline annotation parsing to allow for empty lines e.g. in wrap-doc

### DIFF
--- a/autowrap/PXDParser.py
+++ b/autowrap/PXDParser.py
@@ -79,11 +79,11 @@ def _parse_multiline_annotations(lines):
             line = line[1:].strip()
             if line.endswith(":"):
                 key = line.rstrip(":")
-                line = next(it).strip()
+                line = next(it).lstrip()
                 while line.startswith("#  "):
                     value = line[1:].strip()
                     result[key].append(value)
-                    line = next(it).strip()
+                    line = next(it).lstrip()
             else:
                 key = line
                 result[key] = True


### PR DESCRIPTION
The only requirement after that is that the indentation continues with at least two spaces, which is a bit tedious but better than having no option for new lines.

Another addition would be to get the substring starting after "#  " instead of trimming after "#" so that one can actually
represent indentation, however that would make it dangerous for other "wrap-" instructions which kind of expect trimmed strings (e.g. for class names).