### PR TITLE
Feature/multiline docs

### DIFF
--- a/autowrap/PXDParser.py
+++ b/autowrap/PXDParser.py
@@ -85,7 +85,7 @@ def _parse_multiline_annotations(lines):
                         value = line[3:].rstrip() # rstrip to keep indentation in docs
                     else:
                         value = line[1:].strip()
-                    if not (key != "wrap-doc" and not value): # don't add empty non wrap-doc values
+                    if (key == "wrap-doc" or value): # don't add empty non wrap-doc values
                         result[key].append(value)
                     try:
                         line = next(it).lstrip() # lstrip to keep empty lines in docs

--- a/tests/test_code_generator_minimal.py
+++ b/tests/test_code_generator_minimal.py
@@ -95,6 +95,8 @@ def test_minimal():
 
     assert len(minimal.compute.__doc__) == 297
 
+    assert len(minimal.run.__doc__) == 111
+
     # test members
     assert minimal.m_accessible == 0
     assert minimal.m_const == -1

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -38,6 +38,12 @@ cdef extern from "minimal.hpp":
         # Note how both run3 and run4 have the same implementation - declaring
         # it const in Cython will not affect the result!
         int run(Minimal & ref)
+        # wrap-doc:
+        #  Test for Mulitline Comment
+        #    with indentation
+        #  
+        #  and empty line
+        
         int run2(Minimal *p)
         int run3(Minimal & ref)
         int run4(const Minimal & ref) # attention here!

--- a/tests/test_pxd_parser.py
+++ b/tests/test_pxd_parser.py
@@ -506,3 +506,15 @@ cdef extern from "*":
     assert str(td1.type_) == "A[B[C]]"
     assert str(td2.type_) == "A[C,D[E[F]]]"
     assert str(td3.type_) == "A[Y,B[C[Y],C[Y,D[E]]]]", str(td.type_)
+
+
+def test_multiline_docs():
+    lines = ["# wrap-doc:",
+             "#  first line",
+             "#    second line indented",
+             "#  "]
+    result = autowrap.PXDParser._parse_multiline_annotations(lines)
+
+    assert result["wrap-doc"][0] == "first line"
+    assert result["wrap-doc"][1] == "  second line indented"
+    assert result["wrap-doc"][2] == ""


### PR DESCRIPTION
Added functionality to parse multi line annotations after method declarations. If there is a multi line wrap-doc it is taken with priority over a potential single line wrap-doc. Empty lines and white space indentations are considered as well.
Added two new test, all tests pass and as an example OpenMS gets wrapped without errors.