### PR TITLE
Added cython3 support and support for staticmethod decorator

### DIFF
--- a/.github/workflows/release-autowrap.yaml
+++ b/.github/workflows/release-autowrap.yaml
@@ -49,5 +49,6 @@ jobs:
           prerelease: false
           release_name: ${{ steps.version.outputs.version }}
           tag_name: release/${{ steps.version.outputs.version }}
+          body_path: CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ var
 sdist
 develop-eggs
 .installed.cfg
+.idea
 
 # Installer logs
 pip-log.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+autowrap 0.22.5
+
+- First version that supports Cython 3 (both Cython 3 and our support are experimental)
+- Adds support for @staticmethod decorators

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@ autowrap 0.22.5
 
 - First version that supports Cython 3 (both Cython 3 and our support are experimental)
 - Adds support for @staticmethod decorators
+- Adds support for wrapping (scoped) enum classes

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -167,6 +167,7 @@ class CodeGenerator(object):
 
         self.top_level_code = []
         self.top_level_pyx_code = []
+        self.enum_codes = defaultdict(list)
         self.class_codes = defaultdict(list)
         self.class_codes_extra = defaultdict(list)
         self.class_pxd_codes = defaultdict(list)
@@ -206,18 +207,18 @@ class CodeGenerator(object):
         self.create_foreign_cimports()
         self.create_includes()
 
-        def create_for(clz, method):
+        def create_for(clz, method, codes):
             for resolved in self.resolved:
                 if resolved.wrap_ignore:
                     continue
                 if isinstance(resolved, clz):
-                    method(resolved)
+                    method(resolved, codes)
 
         # first wrap classes, so that self.class_codes[..] is initialized
         # for attaching enums or static functions
-        create_for(ResolvedClass, self.create_wrapper_for_class)
-        create_for(ResolvedEnum, self.create_wrapper_for_enum)
-        create_for(ResolvedFunction, self.create_wrapper_for_free_function)
+        create_for(ResolvedClass, self.create_wrapper_for_class, self.class_codes)
+        create_for(ResolvedEnum, self.create_wrapper_for_enum, self.enum_codes)
+        create_for(ResolvedFunction, self.create_wrapper_for_free_function, self.class_codes)
 
         # resolve extra
         for clz, codes in self.class_codes_extra.items():
@@ -236,6 +237,12 @@ class CodeGenerator(object):
 
         pyx_code += " \n"
         names = set()
+        # Write enum codes first, since for scoped enums, this contains python classes
+        # that need to be present before usage.
+        for n, c in self.enum_codes.items():
+            pyx_code += c.render()
+            pyx_code += " \n"
+            names.add(n)
         for n, c in self.class_codes.items():
             pyx_code += c.render()
             pyx_code += " \n"
@@ -255,7 +262,12 @@ class CodeGenerator(object):
             pxd_code += " \n"
 
         if debug:
+            if self.write_pxd:
+                print("PXD:")
+            else:
+                print("PXD (will not be written):")
             print(pxd_code)
+            print("PYX:")
             print(pyx_code)
         with open(self.target_path, "w") as fp:
             fp.write(pyx_code)
@@ -308,10 +320,13 @@ class CodeGenerator(object):
 
         return iterators, non_iter_methods
 
-    def create_wrapper_for_enum(self, decl):
+    def create_wrapper_for_enum(self, decl, out_codes):
         self.wrapped_enums_cnt += 1
         if decl.cpp_decl.annotations.get("wrap-attach"):
-            name = "__" + decl.name
+            if not decl.scoped:
+                name = "__" + decl.name
+            else:
+                name = "_Py" + decl.name  # __ prefix in python are private members
         else:
             name = decl.name
         L.info("create wrapper for enum %s" % name)
@@ -323,29 +338,38 @@ class CodeGenerator(object):
                    |cdef class $name:
                    |  pass
                  """, name=name)
-        code.add("""
-                   |
-                   |cdef class $name:
-                 """, name=name)
-        for (name, value) in decl.items:
-            code.add("    $name = $value", name=name, value=value)
+
+        if not decl.scoped:
+            code.add("""
+                       |
+                       |cdef class $name:
+                     """, name=name)
+        else:  # for scoped enums we use the python enum class
+            code.add("""
+                       |
+                       |class $name(_PyEnum):
+                     """, name=name)
+        for (optname, value) in decl.items:
+            code.add("    $name = $value", name=optname, value=value)
 
         # Add mapping of int (enum) to the value of the enum (as string)
-        code.add("""
-                |
-                |    def getMapping(self):
-                |        return dict([ (v, k) for k, v in self.__class__.__dict__.items() if isinstance(v, int) ])""" )
+        if not decl.scoped:
+            code.add("""
+                    |
+                    |    def getMapping(self):
+                    |        return dict([ (v, k) for k, v in self.__class__.__dict__.items() if isinstance(v, int) ])""" )
 
-        self.class_codes[decl.name] = code
+        out_codes[decl.name] = code
         self.class_pxd_codes[decl.name] = enum_pxd_code
 
+        # Add an extra member to previously declared class code snippets
         for class_name in decl.cpp_decl.annotations.get("wrap-attach", []):
             code = Code.Code()
             display_name = decl.cpp_decl.annotations.get("wrap-as", [decl.name])[0]
-            code.add("%s = %s" % (display_name, "__" + decl.name))
+            code.add("%s = %s" % (display_name, name))
             self.class_codes[class_name].add(code)
 
-    def create_wrapper_for_class(self, r_class):
+    def create_wrapper_for_class(self, r_class, out_codes):
         """Create Cython code for a single class
         
         Note that the cdef class definition and the member variables go into
@@ -455,7 +479,7 @@ class CodeGenerator(object):
                             """ % r_class.wrap_hash[0], locals())
 
         self.class_pxd_codes[cname] = class_pxd_code
-        self.class_codes[cname] = class_code
+        out_codes[cname] = class_code
 
         cons_created = False
 
@@ -845,7 +869,7 @@ class CodeGenerator(object):
 
         return meth_code
 
-    def create_wrapper_for_free_function(self, decl):
+    def create_wrapper_for_free_function(self, decl, out_codes):
         L.info("create wrapper for free function %s" % decl.name)
         self.wrapped_methods_cnt += 1
         static_clz = decl.cpp_decl.annotations.get("wrap-attach")
@@ -855,7 +879,7 @@ class CodeGenerator(object):
             code = Code.Code()
             static_name = "__static_%s_%s" % (static_clz, decl.name) # name used to attach to class
             code.add("%s = %s" % (decl.name, static_name))
-            self.class_codes[static_clz].add(code)
+            out_codes[static_clz].add(code)
             orig_cpp_name = decl.cpp_decl.name # original cpp name (not displayname)
             code = self._create_wrapper_for_free_function(decl, static_name, orig_cpp_name)
 
@@ -1338,31 +1362,32 @@ class CodeGenerator(object):
                    |#Generated with autowrap %s and Cython (Parser) %s
                    |#cython: c_string_encoding=ascii
                    |#cython: embedsignature=False
-                   |from  libcpp.string  cimport string as libcpp_string
-                   |from  libcpp.string  cimport string as libcpp_utf8_string
-                   |from  libcpp.string  cimport string as libcpp_utf8_output_string
-                   |from  libcpp.set     cimport set as libcpp_set
-                   |from  libcpp.vector  cimport vector as libcpp_vector
-                   |from  libcpp.pair    cimport pair as libcpp_pair
-                   |from  libcpp.map     cimport map  as libcpp_map
-                   |from  libcpp cimport bool
-                   |from  libc.string cimport const_char
-                   |from cython.operator cimport dereference as deref,
+                   |from  enum             import Enum as _PyEnum
+                   |from  libcpp.string   cimport string as libcpp_string
+                   |from  libcpp.string   cimport string as libcpp_utf8_string
+                   |from  libcpp.string   cimport string as libcpp_utf8_output_string
+                   |from  libcpp.set      cimport set as libcpp_set
+                   |from  libcpp.vector   cimport vector as libcpp_vector
+                   |from  libcpp.pair     cimport pair as libcpp_pair
+                   |from  libcpp.map      cimport map  as libcpp_map
+                   |from  libcpp          cimport bool
+                   |from  libc.string     cimport const_char
+                   |from  cython.operator cimport dereference as deref,
                    + preincrement as inc, address as address
                    """ % ("%s.%s.%s" % autowrap_version, Cython.Compiler.Version.watermark))
         if self.include_refholder:
             code.add("""
-                   |from  AutowrapRefHolder cimport AutowrapRefHolder
-                   |from  AutowrapPtrHolder cimport AutowrapPtrHolder
+                   |from  AutowrapRefHolder      cimport AutowrapRefHolder
+                   |from  AutowrapPtrHolder      cimport AutowrapPtrHolder
                    |from  AutowrapConstPtrHolder cimport AutowrapConstPtrHolder
                    """)
         if self.include_shared_ptr == "boost":
             code.add("""
-                   |from  smart_ptr cimport shared_ptr
+                   |from  smart_ptr       cimport shared_ptr
                    """)
         elif self.include_shared_ptr == "std":
             code.add("""
-                   |from libcpp.memory cimport shared_ptr
+                   |from  libcpp.memory   cimport shared_ptr
                    """)
         if self.include_numpy:
             code.add("""

--- a/autowrap/DeclResolver.py
+++ b/autowrap/DeclResolver.py
@@ -179,10 +179,10 @@ class ResolvedClass(object):
         self.no_pxd_import = decl.annotations.get("no-pxd-import", False)
         self.wrap_manual_memory = decl.annotations.get("wrap-manual-memory", [])
         # fix previous code where we had a bool ... 
-        if self.wrap_manual_memory == True:
+        if self.wrap_manual_memory:
             self.wrap_manual_memory = ["__old-model"]
         else:
-            self.wrap_manual_memory == []
+            self.wrap_manual_memory = []
         assert( isinstance(self.wrap_manual_memory, list) )
         self.wrap_hash = decl.annotations.get("wrap-hash", [])
         self.local_map = local_map
@@ -202,9 +202,10 @@ class ResolvedMethod(object):
         "resolved" means that template parameters are resolved.
     """
 
-    def __init__(self, name, result_type, arguments, decl, instance_map,
+    def __init__(self, name, is_static, result_type, arguments, decl, instance_map,
                  local_map):
         self.name = name
+        self.is_static = is_static
         self.result_type = result_type
         self.arguments = arguments
         self.cpp_decl = decl
@@ -596,7 +597,8 @@ def _resolve_method_or_function(method_decl, instance_mapping, local_type_map,
         arg_type = _resolve_alias(arg_type, instance_mapping, local_type_map)
         args.append((arg_name, arg_type))
     name = method_decl.annotations.get("wrap-as", method_decl.name)
-    return clz(name, result_type, args, method_decl, instance_mapping, local_type_map)
+
+    return clz(name, method_decl.is_static, result_type, args, method_decl, instance_mapping, local_type_map)
 
 
 def _resolve_attribute(adecl, instance_mapping, type_map):

--- a/autowrap/DeclResolver.py
+++ b/autowrap/DeclResolver.py
@@ -126,6 +126,7 @@ class ResolvedEnum(object):
 
     def __init__(self, decl):
         self.name = decl.name
+        self.scoped = decl.scoped
         self.wrap_ignore = decl.annotations.get("wrap-ignore", False)
         self.cpp_decl = decl
         self.items = decl.items

--- a/autowrap/Main.py
+++ b/autowrap/Main.py
@@ -188,6 +188,7 @@ def run_cython(inc_dirs, extra_opts, out, warn_level=1):
     directive_defaults["boundscheck"] = False
     directive_defaults["wraparound"] = False
     directive_defaults["language_level"] = sys.version_info.major
+
     options = dict(include_path=inc_dirs,
                    compiler_directives=directive_defaults,
                    cplus=True)

--- a/autowrap/Main.py
+++ b/autowrap/Main.py
@@ -183,7 +183,7 @@ def run_cython(inc_dirs, extra_opts, out, warn_level=1):
         import Cython.Compiler.Options
         directive_defaults = Cython.Compiler.Options.get_directive_defaults()
 
-
+    directive_defaults["binding"] = False
     directive_defaults["boundscheck"] = False
     directive_defaults["wraparound"] = False
     directive_defaults["language_level"] = sys.version_info.major

--- a/autowrap/Main.py
+++ b/autowrap/Main.py
@@ -183,7 +183,8 @@ def run_cython(inc_dirs, extra_opts, out, warn_level=1):
         import Cython.Compiler.Options
         directive_defaults = Cython.Compiler.Options.get_directive_defaults()
 
-    directive_defaults["binding"] = False
+    # TODO merge these options, if compiler_directives is given in extra_opts? Otherwise they are overwritten
+    directive_defaults["binding"] = False  # For backwards-compat to Cython 0.X
     directive_defaults["boundscheck"] = False
     directive_defaults["wraparound"] = False
     directive_defaults["language_level"] = sys.version_info.major

--- a/autowrap/PXDParser.py
+++ b/autowrap/PXDParser.py
@@ -293,6 +293,10 @@ class EnumDecl(BaseDecl):
     def parseTree(cls, node, lines, pxd_path):
         name = node.name
         items = []
+        try:
+            scoped = node.scoped
+        except:
+            scoped = False
         annotations = parse_class_annotations(node, lines)
         current_value = 0
         for item in node.items:
@@ -301,7 +305,7 @@ class EnumDecl(BaseDecl):
             items.append((item.name, current_value))
             current_value += 1
 
-        return cls(name, node.scoped, items, annotations, pxd_path)
+        return cls(name, scoped, items, annotations, pxd_path)
 
     def __str__(self):
         res = "EnumDecl %s : " % self.name

--- a/autowrap/PXDParser.py
+++ b/autowrap/PXDParser.py
@@ -33,8 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from Cython.Compiler.CmdLine import parse_command_line
-from Cython.Compiler.Main import create_default_resultobj, CompilationSource
-from Cython.Compiler import Pipeline
+from Cython.Compiler.Main import create_default_resultobj, CompilationSource, Context
+from Cython.Compiler import Pipeline, FusedNode
 from Cython.Compiler.Scanning import FileSourceDescriptor
 from Cython.Compiler.Nodes import *
 from Cython.Compiler.ExprNodes import *
@@ -55,6 +55,14 @@ Methods in this module use Cythons Parser to build an Cython syntax tree
 from the annotated .pxd files and creates a represenation of the
 included classes and methods.
 """
+
+
+def _check_type_constness(type):
+    """ Regargless of Cython version, checks whether the passed Cython type is const """
+    try:
+        return isinstance(type, Nodes.CConstTypeNode)
+    except:
+        return isinstance(type, Nodes.CConstOrVolatileTypeNode) and type.is_const
 
 
 def parse_class_annotations(node, lines):
@@ -172,7 +180,7 @@ def _extract_template_args(node):
 def _extract_type(base_type, decl):
     """ extracts type information from node in parse_pxd_file tree """
 
-    type_is_const = isinstance(base_type, Nodes.CConstTypeNode)
+    type_is_const = _check_type_constness(base_type)
 
     # Complex const values, e.g. "const Int *" need to be reduced to base type
     # to get the correct name. Note: we will have to deal with const-ness first
@@ -200,7 +208,7 @@ def _extract_type(base_type, decl):
                 # Handle const template arguments which do not have a name
                 # themselves, only their base types have name attribute (see
                 # for example: shared_ptr<const Int>)
-                arg_is_const = isinstance(arg_node.base_type, Nodes.CConstTypeNode)
+                arg_is_const = _check_type_constness(arg_node.base_type)
                 if arg_is_const:
                     name = arg_node.base_type.base_type.name
                 else:
@@ -378,16 +386,17 @@ class CppAttributeDecl(BaseDecl):
 
 
 class CppMethodOrFunctionDecl(BaseDecl):
-    def __init__(self, result_type, name, arguments, annotations, pxd_path):
+    def __init__(self, result_type, name, arguments, is_static, annotations, pxd_path):
         super(CppMethodOrFunctionDecl, self).__init__(name, annotations, pxd_path)
         self.result_type = result_type
         self.arguments = arguments
+        self.is_static = is_static
 
     def transformed(self, typemap):
         result_type = self.result_type.transformed(typemap)
         args = [(n, t.transformed(typemap)) for n, t in self.arguments]
         return CppMethodOrFunctionDecl(
-            result_type, self.name, args, self.annotations, self.pxd_path
+            result_type, self.name, args, self.is_static, self.annotations, self.pxd_path
         )
 
     def matches(self, other):
@@ -412,7 +421,15 @@ class MethodOrAttributeDecl(object):
     def parseTree(cls, node, lines, pxd_path):
         annotations = parse_line_annotations(node, lines)
         if isinstance(node, CppClassNode):
-            return None  # nested classes only can be delcared in pxd
+            return None  # nested classes only can be declared in pxd
+
+        is_static = False
+
+        if isinstance(node, CVarDefNode):
+            if node.decorators is not None:
+                for dec in node.decorators:
+                    if dec.decorator.name == 'staticmethod':
+                        is_static = True
 
         (decl,) = node.declarators
         result_type = _extract_type(node.base_type, decl)
@@ -448,10 +465,11 @@ class MethodOrAttributeDecl(object):
             tt = _extract_type(arg.base_type, argdecl)
             args.append((argname, tt))
 
-        return CppMethodOrFunctionDecl(result_type, name, args, annotations, pxd_path)
+        return CppMethodOrFunctionDecl(result_type, name, args, is_static, annotations, pxd_path)
 
     def __str__(self):
-        rv = str(self.result_type)
+        rv = "static" if self.is_static else ""
+        rv += str(self.result_type)
         rv += " " + self.name
         argl = [str(type_) + " " + str(name) for name, type_ in self.arguments]
         return rv + "(" + ", ".join(argl) + ")"
@@ -490,7 +508,10 @@ def parse_pxd_file(path, warn_level=1):
     source = CompilationSource(source_desc, name, os.getcwd())
     result = create_default_resultobj(source, options)
 
-    context = options.create_context()
+    try:  # Cython 0.X
+        context = options.create_context()
+    except:  # Cython 3.X
+        context = Context.from_options(options)
     pipeline = Pipeline.create_pyx_pipeline(context, options, result)
     context.setup_errors(options, result)
     root = pipeline[0](source)  # only parser

--- a/autowrap/Utils.py
+++ b/autowrap/Utils.py
@@ -84,8 +84,11 @@ def compile_and_import(name, source_files, include_dirs=None, **kws):
     link_args = []
 
     if sys.platform == "darwin":
-        compile_args += ["-stdlib=libc++"]
+        compile_args += ["-stdlib=libc++","-std=c++11"]
         link_args += ["-stdlib=libc++"]
+
+    if sys.platform == "linux" or sys.platform == "linux2":
+        compile_args += ["-std=c++11"]
 
     if sys.platform != "win32":
         compile_args += ["-Wno-unused-but-set-variable"]

--- a/autowrap/version.py
+++ b/autowrap/version.py
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-__version__ = (0, 22, 4)
+__version__ = (0, 22, 5)
 
 
 # for compatibility with older version:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 from setuptools import find_packages, setup
 
 
-VERSION = (0, 22, 4)
+VERSION = (0, 22, 5)
 # DO NOT FORGET TO BUMP THE VERSION IN version.py !!!!!!!!!!!!!!!!!!!
 
 

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -42,20 +42,33 @@ import autowrap.Utils
 import autowrap.Code
 import autowrap
 from Cython.Compiler.Version import version as cython_version
-
 import os
 import math
 import sys
 
 test_files = os.path.join(os.path.dirname(__file__), "test_files")
 
+def test_foo():
+    target = os.path.join(test_files, "enums.pyx")
+
+    include_dirs = autowrap.parse_and_generate_code(["enums.pxd"],
+                                                    root=test_files, target=target, debug=True)
+
+    mod = autowrap.Utils.compile_and_import("enummodule", [target, ], include_dirs)
+
+    foo = mod.Foo()
+    myenumA = mod.Foo.MyEnum.A
+    myenum2A = mod.Foo.MyEnum2.A
+    assert (foo.enumToInt(myenumA) == 1)
+    with pytest.raises(AssertionError):
+        foo.enumToInt(myenum2A)
 
 def test_number_conv():
 
     target = os.path.join(test_files, "number_conv.pyx")
 
     include_dirs = autowrap.parse_and_generate_code(["number_conv.pxd"],
-                                                    root=test_files, target=target,  debug=True)
+                                                    root=test_files, target=target, debug=True)
 
     mod = autowrap.Utils.compile_and_import("number_conv", [target, ], include_dirs)
 

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -41,6 +41,7 @@ import autowrap.PXDParser
 import autowrap.Utils
 import autowrap.Code
 import autowrap
+from Cython.Compiler.Version import version as cython_version
 
 import os
 import math
@@ -189,7 +190,9 @@ def test_templated():
     assert templated_o.xi[1].get() == 12
 
     # Test (wrap-attached) free functions = old way to wrap static functions (can only be called with class)
-    assert templated.computeEight() == 8
+    if int(str(cython_version).split(".")[0]) < 3:
+        assert templated.computeEight() == 8
+        assert templated_o.computeEight() == 8
     assert twrapped.Templated.computeEight() == 8
     assert twrapped.Templated_other.computeEight() == 8
 

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -48,7 +48,9 @@ import sys
 
 test_files = os.path.join(os.path.dirname(__file__), "test_files")
 
-def test_foo():
+def test_enums():
+    if int(cython_version[0]) < 3:
+        return
     target = os.path.join(test_files, "enums.pyx")
 
     include_dirs = autowrap.parse_and_generate_code(["enums.pxd"],

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+import types
+
 import pytest
 
 __license__ = """
@@ -42,10 +44,7 @@ import autowrap
 
 import os
 import math
-import copy
 import sys
-
-from .utils import expect_exception
 
 test_files = os.path.join(os.path.dirname(__file__), "test_files")
 
@@ -189,9 +188,16 @@ def test_templated():
     assert templated_o.xi[0].get() == 11
     assert templated_o.xi[1].get() == 12
 
-    # Test free functions
+    # Test (wrap-attached) free functions = old way to wrap static functions (can only be called with class)
+    assert templated.computeEight() == 8
+    assert twrapped.Templated.computeEight() == 8
+    assert twrapped.Templated_other.computeEight() == 8
+
+    # Test static functions (can be called with or without object)
     assert templated.computeSeven() == 7
     assert templated_o.computeSeven() == 7
+    assert twrapped.Templated.computeSeven() == 7
+    assert twrapped.Templated_other.computeSeven() == 7
 
 def test_gil_unlock():
 

--- a/tests/test_code_generator_libcpp.py
+++ b/tests/test_code_generator_libcpp.py
@@ -110,6 +110,9 @@ def test_libcpp():
 
     t = libcpp.LibCppTest()
 
+    scopedenumclassval = libcpp.LibCppTest.MyEnum.A
+    assert(t.enumToInt(scopedenumclassval) == 1)
+
     assert t.twist([b"hi", 2]) == [2, b"hi"]
     li = [1]
     li2 = t.process(li)

--- a/tests/test_code_generator_libcpp.py
+++ b/tests/test_code_generator_libcpp.py
@@ -110,9 +110,6 @@ def test_libcpp():
 
     t = libcpp.LibCppTest()
 
-    scopedenumclassval = libcpp.LibCppTest.MyEnum.A
-    assert(t.enumToInt(scopedenumclassval) == 1)
-
     assert t.twist([b"hi", 2]) == [2, b"hi"]
     li = [1]
     li2 = t.process(li)

--- a/tests/test_files/enums.hpp
+++ b/tests/test_files/enums.hpp
@@ -1,0 +1,23 @@
+class Foo
+{
+public:
+    enum class MyEnum
+    {
+      A,B,C
+    };
+
+    enum class MyEnum2
+    {
+      A,B,C
+    };
+
+    int enumToInt(MyEnum e)
+    {
+       switch(e)
+       {
+          case MyEnum::A : return 1;
+          case MyEnum::B : return 2;
+          case MyEnum::C : return 3;
+       }
+    };
+};

--- a/tests/test_files/enums.pxd
+++ b/tests/test_files/enums.pxd
@@ -1,0 +1,22 @@
+# cython: language_level=2
+
+cdef extern from "enums.hpp":
+     cdef cppclass Foo:
+
+        int enumToInt(MyEnum e)
+
+cdef extern from "enums.hpp" namespace "Foo":
+
+    cpdef enum class MyEnum "Foo::MyEnum":
+        # wrap-attach:
+        #  Foo
+        A
+        B
+        C
+
+    cpdef enum class MyEnum2 "Foo::MyEnum2":
+        # wrap-attach:
+        #  Foo
+        A
+        B
+        C

--- a/tests/test_files/libcpp_test.hpp
+++ b/tests/test_files/libcpp_test.hpp
@@ -65,6 +65,26 @@ class LibCppTest {
             integer_vector_ptr(0) 
         {}
 
+        enum class MyEnum : int
+        {
+            A,B,C
+        };
+
+        enum class MyEnum2 : int
+        {
+            A,B,C
+        };
+
+        int enumToInt(MyEnum e)
+        {
+            switch(e)
+            {
+                case MyEnum::A : return 1;
+                case MyEnum::B : return 2;
+                case MyEnum::C : return 3;
+            }
+        }
+
         Int * integer_ptr;
         std::vector<Int> * integer_vector_ptr;
 

--- a/tests/test_files/libcpp_test.pxd
+++ b/tests/test_files/libcpp_test.pxd
@@ -61,6 +61,8 @@ cdef extern from "libcpp_test.hpp":
         bool operator==(LibCppTest)
         bool operator!=(LibCppTest)
 
+        int enumToInt(MyEnum e)
+
         libcpp_vector[Int] * integer_vector_ptr
         Int * integer_ptr
 
@@ -134,3 +136,10 @@ cdef extern from "libcpp_test.hpp":
         int process40(ABS_Impl1* in_)
         int process40(ABS_Impl2* in_)
 
+cdef extern from "libcpp_test.hpp" namespace "LibCppTest":
+    cpdef enum class MyEnum(int) :
+        # wrap-attach:
+        #  LibCppTest
+        A,
+        B,
+        C,

--- a/tests/test_files/libcpp_test.pxd
+++ b/tests/test_files/libcpp_test.pxd
@@ -61,8 +61,6 @@ cdef extern from "libcpp_test.hpp":
         bool operator==(LibCppTest)
         bool operator!=(LibCppTest)
 
-        int enumToInt(MyEnum e)
-
         libcpp_vector[Int] * integer_vector_ptr
         Int * integer_ptr
 
@@ -135,11 +133,3 @@ cdef extern from "libcpp_test.hpp":
         # int process40(AbstractBaseClass* in_)
         int process40(ABS_Impl1* in_)
         int process40(ABS_Impl2* in_)
-
-cdef extern from "libcpp_test.hpp" namespace "LibCppTest":
-    cpdef enum class MyEnum(int) :
-        # wrap-attach:
-        #  LibCppTest
-        A,
-        B,
-        C,

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -39,7 +39,7 @@ cdef extern from "minimal.hpp":
         # it const in Cython will not affect the result!
         int run(Minimal & ref)
         # wrap-doc:
-        #  Test for Mulitline Comment
+        #  Test for Multiline Comment
         #    with indentation
         #  
         #  and empty line

--- a/tests/test_files/templated.hpp
+++ b/tests/test_files/templated.hpp
@@ -104,6 +104,11 @@ class Templated {
             return 7;
         }
 
+        static int computeEight()
+        {
+            return 8;
+        }
+
 };
 
 

--- a/tests/test_files/templated.pxd
+++ b/tests/test_files/templated.pxd
@@ -37,15 +37,18 @@ cdef extern from "templated.hpp":
         Templated[X] passs(Templated[X] v)
         bool operator==(Templated[X] other)
 
+        @staticmethod
+        int computeSeven() nogil except +
+
     cdef cppclass Y:
         Y()
         libcpp_vector[Templated[T]] passs(libcpp_vector[Templated[T]] v)
 
 cdef extern from "templated.hpp" namespace "Templated<T2>":
 
-    int computeSeven() nogil except + # wrap-attach:Templated_other
+    int computeEight() nogil except + # wrap-attach:Templated_other
 
 cdef extern from "templated.hpp" namespace "Templated<T>":
 
-    int computeSeven() nogil except + # wrap-attach:Templated
+    int computeEight() nogil except + # wrap-attach:Templated
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -37,10 +37,10 @@ def expect_exception(fun):
             fun(*a, **kw)
         except Exception:
             if 0:
-                print("info: expected excption. here some more info:")
+                print("info: expected exception. here some more info:")
                 import traceback
                 traceback.print_exc()
-                print
+                print()
             pass
         else:
             assert False, "%s did not raise exception" % fun


### PR DESCRIPTION
As you can see in the added tests, Cython3 does not add a member function anymore to attached free functions
and therefore cannot be called with objects anymore.
This might break tests in OpenMS but we should switch to @staticmethod declarators anyway.