### PR TITLE
add wrap-doc for Enums including test

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -345,6 +345,11 @@ class CodeGenerator(object):
                 name = "_Py" + decl.name  # __ prefix in python are private members
         else:
             name = decl.name
+
+        doc = decl.cpp_decl.annotations.get("wrap-doc", [])
+        if doc:
+            doc = '"""\n    ' + '\n    '.join(doc) + '\n    """'
+
         L.info("create wrapper for enum %s" % name)
         code = Code.Code()
         enum_pxd_code = Code.Code()
@@ -359,12 +364,14 @@ class CodeGenerator(object):
             code.add("""
                        |
                        |cdef class $name:
-                     """, name=name)
+                       |    $doc
+                     """, name=name, doc=doc)
         else:  # for scoped enums we use the python enum class
             code.add("""
                        |
                        |class $name(_PyEnum):
-                     """, name=name)
+                       |    $doc
+                     """, name=name, doc=doc)
         for (optname, value) in decl.items:
             code.add("    $name = $value", name=optname, value=value)
 

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -59,6 +59,8 @@ def test_enums():
     mod = autowrap.Utils.compile_and_import("enummodule", [target, ], include_dirs)
 
     foo = mod.Foo()
+    my_enum = mod.Foo.MyEnum
+    assert "Testing Enum documentation." in my_enum.__doc__
     myenum_a = mod.Foo.MyEnum.A
     myenum2_a = mod.Foo.MyEnum2.A
     assert (foo.enumToInt(myenum_a) == 1)

--- a/tests/test_files/enums.pxd
+++ b/tests/test_files/enums.pxd
@@ -10,6 +10,9 @@ cdef extern from "enums.hpp" namespace "Foo":
     cpdef enum class MyEnum "Foo::MyEnum":
         # wrap-attach:
         #  Foo
+        #
+        # wrap-doc:
+        #  Testing Enum documentation.
         A
         B
         C


### PR DESCRIPTION
CodeGenerator includes wrap-doc statements for Enums. Implemented after suggestion by Julianus. A test has been added.