### PR TITLE
Feature/map

### DIFF
--- a/tests/test_code_generator_stllibcpp.py
+++ b/tests/test_code_generator_stllibcpp.py
@@ -175,3 +175,23 @@ def test_stl_libcpp():
     const_res = t.process_11_const()
     const_res.i_ == 42
 
+    # Part 6
+    # Test std::map< string, IntWrapper >
+    i1 = libcpp_stl.IntWrapper(1)
+    i2 = libcpp_stl.IntWrapper(2)
+    map_inp = { b"test" : i2 }
+    assert t.process_12_map(map_inp) == 2 + 10
+    assert len(map_inp) == 1
+    assert list(map_inp.values())[0].i_ == 2 + 10
+
+    # Part 7
+    # Test std::map< Widget, vector<int> >
+    i1 = libcpp_stl.IntWrapper(1)
+    i2 = libcpp_stl.IntWrapper(2)
+    map_inp = { i2 : [6, 2] }
+    assert t.process_13_map(map_inp) == 2
+    assert len(map_inp) == 1
+    assert list(map_inp.values())[0][0] == 6 + 10
+    assert list(map_inp.values())[0][1] == 2
+
+

--- a/tests/test_code_generator_stllibcpp.py
+++ b/tests/test_code_generator_stllibcpp.py
@@ -194,4 +194,15 @@ def test_stl_libcpp():
     assert list(map_inp.values())[0][0] == 6 + 10
     assert list(map_inp.values())[0][1] == 2
 
-
+    # Part 8
+    # Test std::map< Widget, Widget2 >
+    vec_wrapper = libcpp_stl.IntVecWrapper()
+    vec_wrapper.push_back(6)
+    vec_wrapper.push_back(2)
+    i1 = libcpp_stl.IntWrapper(1)
+    i2 = libcpp_stl.IntWrapper(2)
+    map_inp = { i2 : vec_wrapper }
+    assert t.process_14_map(map_inp) == 2
+    assert len(map_inp) == 1
+    assert list(map_inp.values())[0][0] == 6 + 10
+    assert list(map_inp.values())[0][1] == 2

--- a/tests/test_files/libcpp_stl_test.hpp
+++ b/tests/test_files/libcpp_stl_test.hpp
@@ -177,4 +177,24 @@ class LibCppSTLTest {
             boost::shared_ptr<IntWrapper> ptr(new IntWrapper(42));
             return boost::static_pointer_cast<const IntWrapper>(ptr);
         }
+
+        int process_12_map(std::map<std::string, IntWrapper >& in)
+        {
+            if (!in.empty())
+            {
+                in.begin()->second.i_ += 10;
+                return in.begin()->second.i_;
+            }
+            return -1;
+        }
+
+        int process_13_map(std::map<IntWrapper, std::vector<int> >& in)
+        {
+            if (!in.empty() && !in.begin()->second.empty())
+            {
+                in.begin()->second[0] += 10;
+                return in.begin()->first.i_;
+            }
+            return -1;
+        }
 };

--- a/tests/test_files/libcpp_stl_test.hpp
+++ b/tests/test_files/libcpp_stl_test.hpp
@@ -197,4 +197,14 @@ class LibCppSTLTest {
             }
             return -1;
         }
+
+        int process_14_map(std::map<IntWrapper, IntVecWrapper>& in)
+        {
+            if (!in.empty() && !in.begin()->second.iv_.empty())
+            {
+                in.begin()->second.iv_[0] += 10;
+                return in.begin()->first.i_;
+            }
+            return -1;
+        }
 };

--- a/tests/test_files/libcpp_stl_test.pxd
+++ b/tests/test_files/libcpp_stl_test.pxd
@@ -53,3 +53,6 @@ cdef extern from "libcpp_stl_test.hpp":
 
         shared_ptr[const IntWrapper] process_11_const()
 
+        int process_12_map(libcpp_map[libcpp_string, IntWrapper ]& in_)
+        int process_13_map(libcpp_map[IntWrapper, libcpp_vector[int] ]& in_)
+

--- a/tests/test_files/libcpp_stl_test.pxd
+++ b/tests/test_files/libcpp_stl_test.pxd
@@ -15,6 +15,7 @@ cdef extern from "libcpp_stl_test.hpp":
 
     cdef cppclass IntVecWrapper:
         IntVecWrapper()
+        IntVecWrapper(IntVecWrapper&)
         libcpp_vector[int] iv_
 
         int& operator[](size_t index)
@@ -56,3 +57,4 @@ cdef extern from "libcpp_stl_test.hpp":
         int process_12_map(libcpp_map[libcpp_string, IntWrapper ]& in_)
         int process_13_map(libcpp_map[IntWrapper, libcpp_vector[int] ]& in_)
 
+        int process_14_map(libcpp_map[IntWrapper, IntVecWrapper]& in_)


### PR DESCRIPTION
Previously it was not possible to wrap `std::map<Widget, Widget>` as the only support was for *either* key *or* value to be a user-defined type. This PR addresses this and allows wrapping of both key *and* value to be user-defined classes. 