### PR TITLE
Add buffer protocol generator and example

### DIFF
--- a/.github/workflows/ci-autowrap.yaml
+++ b/.github/workflows/ci-autowrap.yaml
@@ -18,19 +18,19 @@ jobs:
 #          - CYTHON: "<=0.29.21"
 #            python-version: "2.7"
           - CYTHON: "<=0.29.21"          
-            python-version: "3.6"
+            python-version: "3.7"
           - CYTHON: "<=0.29.21"          
-            python-version: "3.9"
+            python-version: "3.9" # Cython < 0.29.21 not compatible with 3.10, so neither are we
 #          - CYTHON: ">0.29.21"
 #            python-version: "2.7"
           - CYTHON: ">0.29.21"          
-            python-version: "3.6"
+            python-version: "3.7"
           - CYTHON: ">0.29.21"          
-            python-version: "3.9"
+            python-version: "3.10"
           - CYTHON: "==3.0.0a10"
-            python-version: "3.6"
+            python-version: "3.7"
           - CYTHON: "==3.0.0a10"
-            python-version: "3.9"
+            python-version: "3.10"
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release-autowrap.yaml
+++ b/.github/workflows/release-autowrap.yaml
@@ -66,7 +66,7 @@ jobs:
           echo "\n" >> HISTORY.md
           cat CHANGELOG.md >> HISTORY.md
           rm CHANGELOG.md && echo "autowrap $NEXT_VER" > CHANGELOG.md
-          sed -e -i "s/^[[:space:]]*__version__.*/__version__ = \(${NEXT_VER//./, }\)/g" autowrap/version.py
+          sed -i -e "s/^[[:space:]]*__version__.*/__version__ = \(${NEXT_VER//./, }\)/g" autowrap/version.py
           
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/release-autowrap.yaml
+++ b/.github/workflows/release-autowrap.yaml
@@ -63,8 +63,9 @@ jobs:
           NEXT_VER=${{ github.event.inputs.next_version }}
           OLD_VER=${{ steps.version.outputs.version }}
           [ -z "$NEXT_VER" ] && NEXT_VER=$(echo $OLD_VER | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g') || true
-          echo "\n" >> HISTORY.md
+          echo >> HISTORY.md
           cat CHANGELOG.md >> HISTORY.md
+          echo >> HISTORY.md
           rm CHANGELOG.md && echo "autowrap $NEXT_VER" > CHANGELOG.md
           sed -i -e "s/^[[:space:]]*__version__.*/__version__ = \(${NEXT_VER//./, }\)/g" autowrap/version.py
           

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ tests/test_files/gil_testing_wrapper.pyx
 tests/test_files/libcpp_stl_test.pyx
 tests/test_files/libcpp_utf8_string_test.pyx
 tests/test_files/libcpp_utf8_output_string_test.pyx
+tests/test_files/iteratorwrapper.pyx
+tests/test_files/namespaces.pyx
 tests/test_files/number_conv.pyx
 tests/test_files/enums.pyx
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,1 @@
-autowrap 0.22.8
-- Added support for missing operators '-', '/', '-=', '*=', '/='
-- Refactored special method generation a little, with minor fixes.
-- Finished complete support for type stubs for all? generated Cython code
+autowrap 0.22.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,5 @@
 autowrap 0.22.9
+
+- Typing of a majority of classes and functions of the codebase
+- Requires python 3.7 instead of 3.6 now
+- Support for "const Members" as alternative to "wrap-constant" (experimental)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
 autowrap 0.22.8
 - Added support for missing operators '-', '/', '-=', '*=', '/='
+- Refactored special method generation a little, with minor fixes.
+- Finished complete support for type stubs for all? generated Cython code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 autowrap 0.22.8
+- Added support for missing operators '-', '/', '-=', '*=', '/='

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+Help us to make autowrap better and become part of the OpenMS open-source community.
+
+This document is displayed because you either opened an issue or you want to provide your code as a pull request for inclusion into autowrap. Please take a look at the appropriate section below to find some details on how we handle this process.
+When interacting with other developers, users or anyone else from our community, please adhere to
+[the OpenMS CODE OF CONDUCT](https://github.com/OpenMS/OpenMS/blob/develop/CODE_OF_CONDUCT.md)
+
+# Reporting an Issue:
+
+You most likely came here to:
+  - report bugs or annoyances
+  - pose questions
+  - point out missing documentation
+  - request new features
+
+If you found a bug, e.g. an autowrap tool crashes during code generation, it is essential to provide some basic information:
+  - the autowrap version you are running
+  - the platform you are running autowrap on (Windows 10, ...)
+  - how you installed autowrap (e.g., from source, pip)
+  - a description on how to reproduce the bug
+  - relevant tool output (e.g., error messages)
+  - data to repoduce the bug (If possible as a GitHub gist. Other platforms like Dropbox, Google Drive links also work. If you can't share the data publicly please indicate this and we will contact you in private.)
+
+If you are an official OpenMS team meber:
+  - label your issue using github labels (e.g. as: question, defect) that indicate the type of issue and which components of autowrap (blue labels) are affected. The severity is usually assigned by OpenMS maintainers and used internally to e.g. indicate if a bug is a blocker for a new release.
+
+# Opening a Pull Request
+
+Before getting started we recommend taking a look at the OpenMS GitHub-Wiki: https://github.com/OpenMS/OpenMS/wiki#-for-developers
+
+Before you open the pull request, make sure you
+ - adhere to [our coding conventions](https://github.com/OpenMS/OpenMS/wiki/Coding-conventions)
+ - have [unit tests and functional tests](https://github.com/OpenMS/OpenMS/wiki/Write-tests)
+ - Have [proper documentation](https://github.com/OpenMS/OpenMS/wiki/Coding-conventions#doxygen)
+
+A core developer will review your changes to the main development branch (develop) and approve them (or ask for modifications). You may indicate the prefered reviewer(s) by adding links to them in a comment section (e.g., @cbielow @hendrikweisser @hroest @jpfeuffer @timosachsenberg)
+
+Also consider getting in contact with the core developers early. They might provide additional guidance and valuable information on how your specific aim is achieved. This might give you a head start in, for example, developing novel tools or algorithms.
+
+Happy coding!

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,10 @@
-autowrap 0.22.8
-- Added support for missing operators '-', '/', '-=', '*=', '/='
-- Refactored special method generation a little, with minor fixes.
-- Finished complete support for type stubs for all? generated Cython code
-
 autowrap 0.22.7
 
 - automatically generates pyi typestubs next to the pyx files
+
+
+autowrap 0.22.8
+
+- Added support for missing operators '-', '/', '-=', '*=', '/='
+- Refactored special method generation a little, with minor fixes.
+- Finished complete support for type stubs for all? generated Cython code

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,8 @@
-\n
+autowrap 0.22.8
+- Added support for missing operators '-', '/', '-=', '*=', '/='
+- Refactored special method generation a little, with minor fixes.
+- Finished complete support for type stubs for all? generated Cython code
+
 autowrap 0.22.7
 
 - automatically generates pyi typestubs next to the pyx files

--- a/autowrap/Code.py
+++ b/autowrap/Code.py
@@ -57,17 +57,16 @@ class Code(object):
         self.content = []
 
     def extend(self, other):
-        # keeps identation
+        # keeps indentation
         self.content.extend(other.content)
 
     def add(self, what, *a, **kw):
-        # may increase indent !
+        # may increase indent!
         if a:  # if dict given
             kw.update(a[0])
         if "self" in kw:
             del kw["self"]  # self causes problems in substitute call below
         if isinstance(what, basestring):
-            # print repr(what)
             try:
                 res = string.Template(what).substitute(**kw)
             except:
@@ -78,7 +77,7 @@ class Code(object):
             res = re.sub(r"\n+ *\+", "", res)
             for line in re.split(r"\n *\|", res):
                 self.content.append(line.rstrip())
-        else:
+        else:  # TODO do we really want to allow adding "ANYTHING" e.g. even None?
             self.content.append(what)
         return self
 

--- a/autowrap/Code.py
+++ b/autowrap/Code.py
@@ -1,6 +1,8 @@
 # encoding: utf-8
 
 from __future__ import print_function
+from __future__ import annotations
+from typing import Union, List
 
 __license__ = """
 
@@ -54,13 +56,13 @@ else:
 class Code(object):
 
     def __init__(self):
-        self.content = []
+        self.content: List[Union[Code,str]] = []
 
-    def extend(self, other):
+    def extend(self, other: Code) -> None:
         # keeps indentation
         self.content.extend(other.content)
 
-    def add(self, what, *a, **kw):
+    def add(self, what: Union[str, bytes, Code], *a, **kw) -> Code:
         # may increase indent!
         if a:  # if dict given
             kw.update(a[0])
@@ -69,7 +71,7 @@ class Code(object):
         if isinstance(what, basestring):
             try:
                 res = string.Template(what).substitute(**kw)
-            except:
+            except ValueError:
                 print(what)
                 print(kw)
                 raise
@@ -81,7 +83,7 @@ class Code(object):
             self.content.append(what)
         return self
 
-    def _render(self, _indent=""):
+    def _render(self, _indent="") -> List[str]:
         result = []
         for content in self.content:
             if isinstance(content, basestring):
@@ -91,5 +93,5 @@ class Code(object):
                     result.append(line)
         return result
 
-    def render(self):
+    def render(self) -> str:
         return "\n".join(self._render())

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -690,6 +690,10 @@ class CodeGenerator(object):
                 assert len(methods) == 1, "overloaded operator+ not supported"
                 code = self.create_special_add_method(cdcl, methods[0])
                 return [code], Code.Code()
+            elif op == "-":
+                assert len(methods) == 1, "overloaded operator- not supported"
+                code = self.create_special_sub_method(cdcl, methods[0])
+                return [code], Code.Code()
             elif op == "*":
                 assert len(methods) == 1, "overloaded operator* not supported"
                 code = self.create_special_mul_method(cdcl, methods[0])
@@ -1152,6 +1156,27 @@ class CodeGenerator(object):
         |    cdef $cy_t added = deref(this) + deref(that)
         |    cdef $name result = $name.__new__($name)
         |    result.inst = shared_ptr[$cy_t](new $cy_t(added))
+        |    return result
+        """, locals())
+        return code
+    
+    def create_special_sub_method(self, cdcl, mdcl):
+        L.info("   create wrapper for operator-")
+        assert len(mdcl.arguments) == 1, "operator- has wrong signature"
+        (__, t), = mdcl.arguments
+        name = cdcl.name
+        assert t.base_type == name, "can only subtract to myself"
+        assert mdcl.result_type.base_type == name, "can only return same type"
+        cy_t = self.cr.cython_type(t)
+        code = Code.Code()
+        code.add("""
+        |
+        |def __sub__($name self, $name other not None):
+        |    cdef $cy_t  * this = self.inst.get()
+        |    cdef $cy_t * that = other.inst.get()
+        |    cdef $cy_t subtracted = deref(this) - deref(that)
+        |    cdef $name result = $name.__new__($name)
+        |    result.inst = shared_ptr[$cy_t](new $cy_t(subtracted))
         |    return result
         """, locals())
         return code

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -267,7 +267,7 @@ class CodeGenerator(object):
             pxd_code += c.render()
             pxd_code += " \n"
 
-        pyi_code = "from typing import overload, Any, List, Dict, Tuple, Set, Sequence\n\n"
+        pyi_code = "from typing import overload, Any, List, Dict, Tuple, Set, Sequence, Union \n\n"
         pyi_code += "\n".join(ci.render() for ci in self.top_level_typestub_code)
         pyi_code += "\n\n"
         for n, c in self.typestub_codes.items():

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -706,6 +706,19 @@ class CodeGenerator(object):
                 assert len(methods) == 1, "overloaded operator+= not supported"
                 code = self.create_special_iadd_method(cdcl, methods[0])
                 return [code], Code.Code()
+            elif op == "-=":
+                assert len(methods) == 1, "overloaded operator-= not supported"
+                code = self.create_special_isub_method(cdcl, methods[0])
+                return [code], Code.Code()
+            elif op == "*=":
+                assert len(methods) == 1, "overloaded operator*= not supported"
+                code = self.create_special_imul_method(cdcl, methods[0])
+                return [code], Code.Code()
+            elif op == "/=":
+                assert len(methods) == 1, "overloaded operator/= not supported"
+                code = self.create_special_itruediv_method(cdcl, methods[0])
+                return [code], Code.Code()
+            
 
         if len(methods) == 1:
             code, typestubs = self.create_wrapper_for_nonoverloaded_method(cdcl, py_name, methods[0])
@@ -1228,6 +1241,90 @@ class CodeGenerator(object):
         tl.add("""
                 |cdef extern from "autowrap_tools.hpp":
                 |    void _iadd($cy_t *, $cy_t *)
+                """, locals())
+
+        self.top_level_code.append(tl)
+
+        return code
+
+    def create_special_isub_method(self, cdcl, mdcl):
+        L.info("   create wrapper for operator-")
+        assert len(mdcl.arguments) == 1, "operator- has wrong signature"
+        (__, t), = mdcl.arguments
+        name = cdcl.name
+        assert t.base_type == name, "can only subtract to myself"
+        assert mdcl.result_type.base_type == name, "can only return same type"
+        cy_t = self.cr.cython_type(t)
+        code = Code.Code()
+        code.add("""
+        |
+        |def __isub__($name self, $name other not None):
+        |    cdef $cy_t * this = self.inst.get()
+        |    cdef $cy_t * that = other.inst.get()
+        |    _isub(this, that)
+        |    return self
+        """, locals())
+
+        tl = Code.Code()
+        tl.add("""
+                |cdef extern from "autowrap_tools.hpp":
+                |    void _isub($cy_t *, $cy_t *)
+                """, locals())
+
+        self.top_level_code.append(tl)
+
+        return code
+
+    def create_special_imul_method(self, cdcl, mdcl):
+        L.info("   create wrapper for operator*")
+        assert len(mdcl.arguments) == 1, "operator* has wrong signature"
+        (__, t), = mdcl.arguments
+        name = cdcl.name
+        assert t.base_type == name, "can only multiply to myself"
+        assert mdcl.result_type.base_type == name, "can only return same type"
+        cy_t = self.cr.cython_type(t)
+        code = Code.Code()
+        code.add("""
+        |
+        |def __imul__($name self, $name other not None):
+        |    cdef $cy_t * this = self.inst.get()
+        |    cdef $cy_t * that = other.inst.get()
+        |    _imul(this, that)
+        |    return self
+        """, locals())
+
+        tl = Code.Code()
+        tl.add("""
+                |cdef extern from "autowrap_tools.hpp":
+                |    void _imul($cy_t *, $cy_t *)
+                """, locals())
+
+        self.top_level_code.append(tl)
+
+        return code
+    
+    def create_special_itruediv_method(self, cdcl, mdcl):
+        L.info("   create wrapper for operator/")
+        assert len(mdcl.arguments) == 1, "operator/ has wrong signature"
+        (__, t), = mdcl.arguments
+        name = cdcl.name
+        assert t.base_type == name, "can only divide to myself"
+        assert mdcl.result_type.base_type == name, "can only return same type"
+        cy_t = self.cr.cython_type(t)
+        code = Code.Code()
+        code.add("""
+        |
+        |def __itruediv__($name self, $name other not None):
+        |    cdef $cy_t * this = self.inst.get()
+        |    cdef $cy_t * that = other.inst.get()
+        |    _itruediv(this, that)
+        |    return self
+        """, locals())
+
+        tl = Code.Code()
+        tl.add("""
+                |cdef extern from "autowrap_tools.hpp":
+                |    void _itruediv($cy_t *, $cy_t *)
                 """, locals())
 
         self.top_level_code.append(tl)

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -149,7 +149,7 @@ class CodeGenerator(object):
         self.all_classes = self.classes
         self.all_resolved = self.resolved
         if len(allDecl) > 0:
-            
+
             self.all_typedefs = []
             self.all_enums = []
             self.all_functions = []
@@ -191,6 +191,7 @@ class CodeGenerator(object):
 
         pxd_dirs = set()
         for inst in self.all_classes + self.all_enums + self.all_functions + self.all_typedefs:
+            # Could this not simply be `for inst in self.all_resolved:` ?
             pxd_path = os.path.abspath(inst.cpp_decl.pxd_path)
             pxd_dir = os.path.dirname(pxd_path)
             pxd_dirs.add(pxd_dir)
@@ -395,7 +396,7 @@ class CodeGenerator(object):
 
     def create_wrapper_for_class(self, r_class, out_codes):
         """Create Cython code for a single class
-        
+
         Note that the cdef class definition and the member variables go into
         the .pxd file while the Python-level implementation goes into the .pyx
         file. This allows us to cimport these classes later across modules.
@@ -718,7 +719,7 @@ class CodeGenerator(object):
                 assert len(methods) == 1, "overloaded operator/= not supported"
                 code = self.create_special_itruediv_method(cdcl, methods[0])
                 return [code], Code.Code()
-            
+
 
         if len(methods) == 1:
             code, typestubs = self.create_wrapper_for_nonoverloaded_method(cdcl, py_name, methods[0])
@@ -1155,7 +1156,7 @@ class CodeGenerator(object):
         |    return result
         """, locals())
         return code
-        
+
     def create_special_truediv_method(self, cdcl, mdcl):
         L.info("   create wrapper for operator/")
         assert len(mdcl.arguments) == 1, "operator/ has wrong signature"
@@ -1197,7 +1198,7 @@ class CodeGenerator(object):
         |    return result
         """, locals())
         return code
-    
+
     def create_special_sub_method(self, cdcl, mdcl):
         L.info("   create wrapper for operator-")
         assert len(mdcl.arguments) == 1, "operator- has wrong signature"
@@ -1302,7 +1303,7 @@ class CodeGenerator(object):
         self.top_level_code.append(tl)
 
         return code
-    
+
     def create_special_itruediv_method(self, cdcl, mdcl):
         L.info("   create wrapper for operator/")
         assert len(mdcl.arguments) == 1, "operator/ has wrong signature"
@@ -1535,7 +1536,7 @@ class CodeGenerator(object):
         we may be using in this compilation unit. Since we are passing objects
         as arguments quite frequently, we need to know about all other wrapped
         classes and we need to cimport them.
-        
+
         E.g. if we have module1 containing classA, classB and want to access it
         through the pxd header, then we need to add:
 
@@ -1555,7 +1556,7 @@ class CodeGenerator(object):
                 for resolved in self.allDecl[module]["decls"]:
 
                     # We need to import classes and enums that could be used in
-                    # the Cython code in the current module 
+                    # the Cython code in the current module
 
                     # use Cython name, which correctly imports template classes (instead of C name)
                     name = resolved.name
@@ -1578,7 +1579,7 @@ class CodeGenerator(object):
                             else:
                                 code.add("from $mname cimport $name", locals())
 
-            else: 
+            else:
                 L.info("Skip imports from self (own module %s)" % module)
 
         self.top_level_code.append(code)

--- a/autowrap/ConversionProvider.py
+++ b/autowrap/ConversionProvider.py
@@ -188,7 +188,7 @@ class TypeConverterBase(object):
         :param cpp_type: cpp type
         :return: python equivalent for static typing
         """
-        return ""
+        return "Any"
         #raise NotImplementedError()
 
     def type_check_expression(self, cpp_type, argument_var):

--- a/autowrap/ConversionProvider.py
+++ b/autowrap/ConversionProvider.py
@@ -289,7 +289,7 @@ class IntegerConverter(TypeConverterBase):
         return "int"
 
     def type_check_expression(self, cpp_type, argument_var):
-        return "isinstance(%s, (int, long))" % (argument_var,)
+        return "isinstance(%s, int)" % (argument_var,)
 
     def input_conversion(self, cpp_type, argument_var, arg_num):
         code = ""
@@ -322,7 +322,7 @@ class UnsignedIntegerConverter(TypeConverterBase):
         return "int"
 
     def type_check_expression(self, cpp_type, argument_var):
-        return "isinstance(%s, (int, long)) and %s >= 0" % (argument_var, argument_var,)
+        return "isinstance(%s, int) and %s >= 0" % (argument_var, argument_var,)
 
     def input_conversion(self, cpp_type, argument_var, arg_num):
         code = ""

--- a/autowrap/Main.py
+++ b/autowrap/Main.py
@@ -201,9 +201,9 @@ def run_cython(inc_dirs, extra_opts, out, warn_level=1):
 def create_wrapper_code(decls, instance_map, addons, converters, out, extra_inc_dirs, extra_opts, include_boost=True, allDecl=[]):
     cimports, manual_code = collect_manual_code(addons)
     register_converters(converters)
-    inc_dirs = autowrap.generate_code(decls, instance_map=instance_map, target=out, 
-            debug=False, manual_code=manual_code, 
-            extra_cimports=cimports, include_boost=include_boost, allDecl=allDecl)
+    inc_dirs = autowrap.generate_code(decls, instance_map=instance_map, target=out,
+                                      debug=False, manual_code=manual_code,
+                                      extra_cimports=cimports, include_boost=include_boost, all_decl=allDecl)
 
     if extra_inc_dirs is not None:
         inc_dirs += extra_inc_dirs

--- a/autowrap/PXDParser.py
+++ b/autowrap/PXDParser.py
@@ -150,7 +150,7 @@ def parse_line_annotations(node, lines):
                     result[key] += value
       except Exception as e:
         raise ValueError("Cannot parse '{}'".format(line)) from e
-    
+
     # check for multi line annotations after method declaration
     additional_annotations = _parse_multiline_annotations(lines[end:])
     # add multi line doc string to result (overwrites single line wrap-doc, if exists)

--- a/autowrap/Types.py
+++ b/autowrap/Types.py
@@ -1,4 +1,5 @@
 # encoding: utf-8
+from __future__ import annotations
 
 __license__ = """
 
@@ -34,6 +35,9 @@ import copy
 import re
 
 import logging as L
+
+from typing import AnyStr, Dict
+
 
 class CppType(object):
 
@@ -211,16 +215,16 @@ class CppType(object):
             t._collect_base_types(base_types)
 
     @staticmethod
-    def from_string(str_):
+    def from_string(str_: AnyStr) -> CppType:
         return CppType._from_string(str_)
 
     @staticmethod
-    def _from_string(str_):
+    def _from_string(str_: AnyStr) -> CppType:
         # TODO is there a reason why "_" is not in the regex?
         matched = re.match(r"([a-zA-Z0-9][ a-zA-Z0-9_]*)(\[.*\])? *[&\*]?",
                            str_.strip())
         if matched is None:
-            raise Exception("can not parse '%s'" % str_)
+            raise ValueError("can not parse '%s'" % str_)
         base_type, t_str = matched.groups()
         if t_str is None:
             orig_for_error_message = base_type
@@ -269,7 +273,7 @@ class CppType(object):
         return CppType(base_type, t_types, is_ref=is_ref, is_ptr=is_ptr)
 
 
-def printable(type_map, join_str=", "):
+def printable(type_map: Dict[AnyStr, CppType], join_str: str = ", ") -> str:
     if not type_map:
         return "None"
     rules = sorted("%s -> %s" % (k, v) for (k, v) in type_map.items())

--- a/autowrap/__init__.py
+++ b/autowrap/__init__.py
@@ -65,7 +65,7 @@ def generate_code(decls, instance_map, target, debug=False, manual_code=None,
                                       allDecl=allDecl,
                                       add_relative=add_relative,
                                       shared_ptr=shared_ptr)
-    gen.include_numpy=include_numpy
+    gen.include_numpy = include_numpy
     gen.create_pyx_file(debug)
     includes = gen.get_include_dirs(include_boost)
     print("Autowrap has wrapped %s classes, %s methods and %s enums" % (

--- a/autowrap/__init__.py
+++ b/autowrap/__init__.py
@@ -53,16 +53,15 @@ def parse(files, root, num_processes=1, cython_warn_level=1):
 
 
 def generate_code(decls, instance_map, target, debug=False, manual_code=None,
-                  extra_cimports=None, include_boost=True, include_numpy=False, allDecl=[], add_relative=False, shared_ptr="boost"):
-
-
+                  extra_cimports=None, include_boost=True, include_numpy=False,
+                  all_decl=[], add_relative=False, shared_ptr="boost"):
     import autowrap.CodeGenerator
     gen = CodeGenerator.CodeGenerator(decls,
                                       instance_map,
                                       pyx_target_path=target,
                                       manual_code=manual_code,
-                                      extra_cimports=extra_cimports, 
-                                      allDecl=allDecl,
+                                      extra_cimports=extra_cimports,
+                                      all_decl=all_decl,
                                       add_relative=add_relative,
                                       shared_ptr=shared_ptr)
     gen.include_numpy = include_numpy

--- a/autowrap/data_files/autowrap/autowrap_tools.hpp
+++ b/autowrap/data_files/autowrap/autowrap_tools.hpp
@@ -9,6 +9,21 @@ template<class A> void _iadd(A * a1, const A * a2)
     (*a1) += (*a2);
 }
 
+template<class A> void _isub(A * a1, const A * a2)
+{
+    (*a1) -= (*a2);
+}
+
+template<class A> void _imul(A * a1, const A * a2)
+{
+    (*a1) *= (*a2);
+}
+
+template<class A> void _itruediv(A * a1, const A * a2)
+{
+    (*a1) /= (*a2);
+}
+
 namespace autowrap {
 
     template <class X>

--- a/autowrap/version.py
+++ b/autowrap/version.py
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-__version__ = (0, 22, 8)
+__version__ = (0, 22, 9)
 
 
 # for compatibility with older version:

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ class IntHolder {
         int i_;
         IntHolder(int i): i_(i) {};
         IntHolder(const IntHolder & i): i_(i.i_) {};
-        int add(const IntHolder & other) 
+        int add(const IntHolder & other)
         {
             return i_ + other.i_;
         }
@@ -44,7 +44,7 @@ which will generate Cython code that allows direct access to the public
 internal variable `i_` as well as to the two constructors and the public `add`
 method.
 
-Compiling 
+Compiling
 -------------
 
 To compile the above examples to .pyx and .cpp files, go to the `./example`
@@ -129,7 +129,7 @@ you could generate the following .pyx file and run autowrap (see below for a lis
             #   TemplatedWithDouble := TemplateClassName[double]
             #
             # wrap-doc:
-            #   TemplatedClass for double and float, 
+            #   TemplatedClass for double and float,
             #   useful for processing foobars
 
             TemplateType myInner_
@@ -164,7 +164,7 @@ directives are:
 - `wrap-constant`: Useful for constant properties that should have `__get__` but no `__set__`
 - `wrap-upper-limit`: Can be used to check input argument of type int (e.g. for operator[]) to make sure the input integer does not exceed the limit
 - `wrap-cast`: Wrap casting functions such as `double operator()(MyObject)`
-- `wrap-inherits`: Inherit methods from parent classes (see below for example) 
+- `wrap-inherits`: Inherit methods from parent classes (see below for example)
 - `wrap-instances`: Wrap specific template instances (see below for example)
 - `wrap-manual-memory`: will allow the user to provide manual memory management
   of `self.inst`, therefore the class will not provide the automated
@@ -179,7 +179,7 @@ directives are:
 - `wrap-with-no-gil`: Autowrap will release the GIL (Global interpreter lock)
   before calling this method, so that it does not block other Python threads.
   It is advised to release the GIL for long running, expensive calls into
-  native code which does not manipulate python objects. 
+  native code which does not manipulate python objects.
 
 ### Method Directives
 
@@ -200,10 +200,10 @@ Example declaration for releasing the GIL (in the pxd):
 Example for multiple wrap statements in a method directive:
 
 ```
-    size_t countSomething(libcpp_vector[double] inpVec) nogil # wrap-attach:Counter wrap-as:count 
+    size_t countSomething(libcpp_vector[double] inpVec) nogil # wrap-attach:Counter wrap-as:count
 ```
-    
-In addition you have to declare the function as nogil. For further details see 
+
+In addition you have to declare the function as nogil. For further details see
 http://docs.cython.org/src/userguide/external_C_code.html
 
 
@@ -248,24 +248,24 @@ taken with priority.
         # wrap-doc:
         #  Multi line docstring for class
         #    with indentation
-        #  
+        #
         #  and empty line
 
         size_t count(libcpp_vector[double] inpVec) # wrap-doc:Single line docstring that will be overwritten by multi line wrap-doc
         # wrap-doc:
         #  Multi line docstring for method
         #    with indentation
-        #  
+        #
         #  and empty line
 ```
 
 Test examples
 -------------
 
-The tests provide several examples on how to wrap tricky C++ constructs, see for example 
+The tests provide several examples on how to wrap tricky C++ constructs, see for example
 
 - [minimal.pxd](../tests/test_files/minimal.pxd) for a class example that uses static methods, pointers, operators ([], +=, \*, etc) and iterators
-- [libcpp_stl_test.pxd](../tests/test_files/libcpp_stl_test.pxd) for examples using the STL 
+- [libcpp_stl_test.pxd](../tests/test_files/libcpp_stl_test.pxd) for examples using the STL
 - [libcpp_test.pxd](../tests/test_files/libcpp_test.pxd) for a set of C++ functions that use abstract base classes
 - [libcpp_utf8_string_test.pxd](../tests/test_files/libcpp_utf8_string_test.pxd) for an example using UTF8 strings
 - [templated.pxd](../tests/test_files/templated.pxd) for an example using templated classes
@@ -293,3 +293,120 @@ autowrap and split up the compilation into multiple units where each unit
 contains some of the projects classes. For an example on how to do this, see
 `./tests/test_full_library.py`.
 
+High Level Overview
+--------------
+Broadly speaking, the autowrap process consists of two steps:
+1. `DeclResolver` uses the `PXDParser` to parse files
+2. `CodeGenerator` generates code
+
+## Parsing
+
+The process is kicked off by the autowrap `parse` function. This method takes
+a list of files and a root directory as required parameters and optional parameters
+for designating the number of prcesses to use and the cython warning level. The
+method calls `DeclResolver#resolve_decls_from_files` with the given parameters.
+
+Depending on the number of processes passed to the `parse` function, the
+`resolve_decls_from_files` method calls either a single or multi threaded method
+which calls the `PXDParser#parse_pxd_file` method on each given file.
+
+The method `parse_pxd_file` uses the file path passed ot it to build Cython
+`Context` and `Pipeline` objects. These objects are used to create a `root`
+object. This object is passed to an `iter_bodies` method which extracts all the
+Cython `node` objects present in the .pyx file. These objects are used as keys
+to find the appropriate `BaseDecl` class for each node. These `BaseDecl` objects
+are put into a Python list and passed back to the calling `DeclResolver` method (either
+the `resolve_decls_from_files_single_thread` or `resolve_decls_from_files_multi_thread`
+method), which then passes `decls` to the private method `DeclResolver#_resolve_decls`.
+
+The `_resolve_decls` method starts by organizing each `BaseDecl` object by its
+specific subclass (e.g., `CTypeDefDecl`, `EnumDecl`, etc). The method then handles
+the data processing specific to each type of declaration and puts them into a list
+of `Resolved*` objects (`ResolvedEnum` for example). The method also creates a dictionary
+object called `instance_mapping` which contains class instantiations. Finally, the
+`_resolve_decls` method returns a tuple of the resolved declaration objects and
+`instance_mapping` dict.
+
+## Code Generation
+
+### Building a `CodeGenerator` object
+
+The second part of the process is to call the autowrap `generate_code` method. This
+method takes the list of resolved declaration objects and `instance_mapping` dict
+generated from the `parse` method. The `generate_code` method also requires a
+`target` argument for designating the name and path of the .pyx file to be generated.
+
+The `gerneate_code` method builds a `CodeGenerator` object with its inputs. This object's
+constructor first does some preprocessing to file paths and set other configurations.
+Then, it gets all the classes, enums, functions, and typedefs of resolved declarations
+and puts them into a Python list called `resolved`. It then builds an `instance_mapping`
+instance attribute from both the `instance_mapping` argument passed to it, as well as
+instances extracted from the resolved typedefs.
+
+The constructor then checks for items in the `allDecl` argument. This argument will
+have items in it if the user is parsing many files instead of just one. When this is
+the case, the `CodeGenerator` constructor builds an `all_resolved` list which contains
+instances of resolved classes, enums, functions, and typdefs from both the `resolved`
+list, and the `allDecl` object.
+
+Finally, the `CodeGenerator` constructor instantiates an instance variable called `cr`,
+which stands for _container registry_ by calling the
+`ConversionProvider#setup_converter_registry` method. This method takes lists of classes
+and enums to wrap, as well as an instance map. From these values, the method creates
+a new instance of the `ConverterRegistry` method and calls its `register` method on
+each supported type of converter supported by autowrap.
+
+The `register` method builds a hash containing the base type of declarations to be
+converted as keys and maps the appropriate converter class to that key. For example,
+a `void` declaration maps to a `VoidConverter`.
+
+### Creating a .pyx file
+Once the `CodeGenerator` object has been built, the `generate_code` method t hen calls
+the object's `create_pyx_file` method. This method is responsible for actually generating
+the Cython code. It starts by setting up the cimport paths by calling its own
+`setup_cimport_paths` method. This method finds the exact location of each .pxd file
+of the `cpp_decl` objects of each resolved declaration object of the `CodeGenerator` class.
+
+This method sets the `CodeGenerator` object's `pxd_import_path` instance attribute to the
+location of the .pxd file. The method also ensures that all .pxd files are located in one
+directory, then sets the `pxd_dir` instance attribute as that directory.
+
+With the cimport paths set, the `create_pyx_file` can then create the cimports by calling
+the `create_cimports` method. This method first imports standard and extra modules if
+they were designated in the `CodeGenerator` constructor.
+
+Then, the `create_cimports` method instantiates a `Code` object. Then, the method iterates
+through each item in its `all_resolved` attribute and adds lines of code to the `Code`
+object, which interpolates local variables into parts of the pseudo code strings prefixed
+with a `$` character. Finally, the `create_cimports` method appends that code to the
+`CodeGenerator`'s `top_level_code` attribute.
+
+With the cimports created, the `create_pyx_file` method creates the foreign cimports,
+other classes created by autowrap, by callings the `create_foreign_cimports` method.
+This method creates a `Code` object and generates a line of code for every extra
+module that needs to be imported.
+
+The next step in the `create_pyx_file` is to create includes, which it does by calling
+the `create_includes` method. This method again builds a `Code` object that appends a
+line for including a cdef line in the `top_level_code` attribute.
+
+Next, the `create_pyx_file` method calls the appropriate wrapper method for classes,
+enums, and free functions. These methods generate the Cython code necessary to
+wrap those items and does so by creating `Code` objects and appending interpolated
+strings into them.
+
+As one last bit of preparation, the `create_pyx_file` method then resolves any
+extra classes not resolved in the previous steps.
+
+Finally, the `create_pyx_file` begins writing code to the .pyx file. It does this
+by calling the `render` function on each `Code` object in its `top_level_code` and
+`top_level_pyx_code` attributes. This `render` method builds a list of Cython code
+expressions with proper indentation.
+
+Finally, the `create_pyx_file` method creates files objects and writes the generated
+pyi, pyx, and pxd code to their relevant files.
+
+Finally, back in the autowrap `__init__` file, the `generate_code` method gathers
+the include directories by calling `CodeGenerator`'s `get_include_dirs` method. This
+method returns a list of packaged resources from the Cython code generated in the previous
+steps. This value is then returned by the `generate_code` method, completing the second step.

--- a/example/setup.py
+++ b/example/setup.py
@@ -11,9 +11,15 @@ ext = Extension("py_int_holder",
                 include_dirs = [include_dir, data_dir],
                )
 
+ext2 = Extension("py_vec_holder",
+                sources = ['py_vec_holder.cpp'],
+                language="c++",
+                include_dirs = [include_dir, data_dir],
+               )
+
 setup(cmdclass={'build_ext':build_ext},
       name="py_int_holder",
       version="0.0.1",
-      ext_modules = [ext]
+      ext_modules = [ext, ext2]
      )
 

--- a/example/test_buffer.py
+++ b/example/test_buffer.py
@@ -1,0 +1,11 @@
+import py_vec_holder
+import numpy as np
+
+holder = py_vec_holder.VecHolder()
+holder.add(1.0)
+holder.add(2.0)
+holder.add(3.0)
+
+view = np.asarray(holder)
+assert np.allclose(view, [1.0, 2.0, 3.0])
+assert view.base.obj is holder

--- a/example/vec_holder.hpp
+++ b/example/vec_holder.hpp
@@ -1,0 +1,29 @@
+#include <vector>
+
+class VecHolder
+{
+public:
+    std::vector<float> data_;
+    VecHolder() : data_() {};
+    VecHolder(std::vector<float> data) : data_(data){};
+
+    float& get(size_t i)
+    {
+        return data_[i];
+    }
+
+    float& operator[](size_t i)
+    {
+        return data_[i];
+    }
+
+    size_t add(float value) {
+        data_.push_back(value);
+        return size();
+    }
+
+    size_t size() { return data_.size(); }
+
+    std::vector<float>::iterator begin() { return data_.begin(); }
+    std::vector<float>::iterator end() { return data_.end(); }
+};

--- a/example/vec_holder.pxd
+++ b/example/vec_holder.pxd
@@ -1,0 +1,16 @@
+from libcpp.vector cimport vector as libcpp_vector
+
+cdef extern from "vec_holder.hpp":
+    cdef cppclass VecHolder:
+        # wrap-buffer-protocol:
+        #    data_.data(),float,size()
+        #
+        libcpp_vector[float] data_
+
+        VecHolder()
+        VecHolder(libcpp_vector[float] data)
+
+        size_t add(float value)
+        float& operator[](size_t index) #wrap-upper-limit:size()
+        size_t size()
+

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,10 @@ setup(
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Code Generators",
     ],
     long_description="""

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -128,6 +128,21 @@ def test_shared_ptr():
     assert h1.count() == 1
     assert h1.size() == 4
 
+
+def test_inherited():
+
+    target = os.path.join(test_files, "inherited.pyx")
+    include_dirs = autowrap.parse_and_generate_code(["inherited.pxd"],
+                                                    root=test_files, target=target, debug=True)
+
+    mod = autowrap.Utils.compile_and_import("inheritedmodule", [target, ], include_dirs)
+    print(mod.__name__)
+    i = mod.InheritedInt()
+    assert i.foo() == 1
+    assert i.bar() == 0
+    assert i.getBase() == 1
+    assert i.getBaseZ() == 0
+
 def test_templated():
 
     target = os.path.join(test_files, "templated_wrapper.pyx")

--- a/tests/test_code_generator_libcpp.py
+++ b/tests/test_code_generator_libcpp.py
@@ -316,10 +316,10 @@ def test_libcpp():
     t.integer_vector_ptr = [i1, i2, i3]
     assert len(t.integer_vector_ptr) == 3
 
-
-    # process35 uses a const shared_ptr of which it makes a copy
+    # process35 uses a shared_ptr for a const type, of which it makes a copy
     # This means that i1, i2 and i3 are three distinct objects that will not
     # affect each other when manipulated
+    # TODO other option would be to have a second IntConst Wrapper type with only const methods
     i1 = libcpp.Int(20)
     i2 = t.process35(i1)
     assert isinstance(i2, libcpp.Int)

--- a/tests/test_code_generator_minimal.py
+++ b/tests/test_code_generator_minimal.py
@@ -263,6 +263,13 @@ def test_minimal():
     m1 = m1 + m1
     assert m1 == wrapped.Minimal(2)
 
+    # operator sub
+    assert wrapped.Minimal(5) - wrapped.Minimal(2) == wrapped.Minimal(3)
+
+    m1 = wrapped.Minimal(1)
+    m1 = m1 - m1
+    assert m1 == wrapped.Minimal(0)
+
     # operator mult
     assert wrapped.Minimal(5) * wrapped.Minimal(2) == wrapped.Minimal(10)
 

--- a/tests/test_code_generator_minimal.py
+++ b/tests/test_code_generator_minimal.py
@@ -100,12 +100,20 @@ def test_minimal():
     # test members
     assert minimal.m_accessible == 0
     assert minimal.m_const == -1
+    assert minimal.m_constdef == -1
 
     minimal.m_accessible = 10
     assert minimal.m_accessible == 10
 
     try:
         minimal.m_const = 10
+        assert False
+    except AttributeError:
+        # That is what we expected, cant modify a const member
+        pass
+
+    try:
+        minimal.m_constdef = 10
         assert False
     except AttributeError:
         # That is what we expected, cant modify a const member

--- a/tests/test_code_generator_minimal.py
+++ b/tests/test_code_generator_minimal.py
@@ -279,4 +279,11 @@ def test_minimal():
     assert m1 == wrapped.Minimal(9)
     assert m2 == wrapped.Minimal(81)
 
+    # operator div
+    assert wrapped.Minimal(10) / wrapped.Minimal(2) == wrapped.Minimal(5)
+
+    m1 = wrapped.Minimal(3)
+    m1 = m1 / m1
+    assert m1 == wrapped.Minimal(1)
+
 

--- a/tests/test_code_generator_minimal.py
+++ b/tests/test_code_generator_minimal.py
@@ -267,14 +267,14 @@ def test_minimal():
     assert wrapped.Minimal(5) - wrapped.Minimal(2) == wrapped.Minimal(3)
 
     m1 = wrapped.Minimal(1)
-    m1 = m1 - m1
+    m1 -= m1
     assert m1 == wrapped.Minimal(0)
 
     # operator mult
     assert wrapped.Minimal(5) * wrapped.Minimal(2) == wrapped.Minimal(10)
 
     m1 = wrapped.Minimal(3)
-    m1 = m1 * m1
+    m1 *= m1
     m2 = m1 * m1
     assert m1 == wrapped.Minimal(9)
     assert m2 == wrapped.Minimal(81)
@@ -283,7 +283,7 @@ def test_minimal():
     assert wrapped.Minimal(10) / wrapped.Minimal(2) == wrapped.Minimal(5)
 
     m1 = wrapped.Minimal(3)
-    m1 = m1 / m1
+    m1 /= m1
     assert m1 == wrapped.Minimal(1)
 
 

--- a/tests/test_code_generator_minimal.py
+++ b/tests/test_code_generator_minimal.py
@@ -111,7 +111,6 @@ def test_minimal():
         # That is what we expected, cant modify a const member
         pass
 
-
     assert minimal.compute(3) == 4
     # overloaded for float:
     assert minimal.compute(0.0) == 42.0
@@ -224,6 +223,11 @@ def test_minimal():
     assert b == m1
     assert c == m3
 
+    c, b, a = list(reversed(m2))  # call __reversed__
+    assert a == m2
+    assert b == m1
+    assert c == m3
+
     assert m2.test2Lists([m1], [1, 2]) == 3
     assert m1 == m1
 
@@ -247,10 +251,10 @@ def test_minimal():
 
     # Was OverflowError, but now we check positivity for unsigned ints
     with pytest.raises(AssertionError):
-        m2[-1]
+        print(m2[-1])
 
     with pytest.raises(IndexError):
-        m2[3]
+        print(m2[3])
 
     # operator add
     assert wrapped.Minimal(1) + wrapped.Minimal(2) == wrapped.Minimal(3)

--- a/tests/test_code_generator_stllibcpp.py
+++ b/tests/test_code_generator_stllibcpp.py
@@ -173,7 +173,7 @@ def test_stl_libcpp():
 
     # Test shared_ptr < const Widget >
     const_res = t.process_11_const()
-    const_res.i_ == 42
+    assert const_res.i_ == 42
 
     # Part 6
     # Test std::map< string, IntWrapper >

--- a/tests/test_files/buffer/vec_holder.hpp
+++ b/tests/test_files/buffer/vec_holder.hpp
@@ -1,0 +1,30 @@
+#include <vector>
+
+class VecHolder
+{
+public:
+    std::vector<float> data_;
+    VecHolder() : data_(){};
+    VecHolder(std::vector<float> data) : data_(data){};
+
+    float &get(size_t i)
+    {
+        return data_[i];
+    }
+
+    float &operator[](size_t i)
+    {
+        return data_[i];
+    }
+
+    size_t add(float value)
+    {
+        data_.push_back(value);
+        return size();
+    }
+
+    size_t size() { return data_.size(); }
+
+    std::vector<float>::iterator begin() { return data_.begin(); }
+    std::vector<float>::iterator end() { return data_.end(); }
+};

--- a/tests/test_files/buffer/vec_holder.pxd
+++ b/tests/test_files/buffer/vec_holder.pxd
@@ -1,0 +1,16 @@
+from libcpp.vector cimport vector as libcpp_vector
+
+cdef extern from "vec_holder.hpp":
+    cdef cppclass VecHolder:
+        # wrap-buffer-protocol:
+        #    data_.data(),float,size()
+        #
+        libcpp_vector[float] data_
+
+        VecHolder()
+        VecHolder(libcpp_vector[float] data)
+
+        size_t add(float value)
+        float& operator[](size_t index) #wrap-upper-limit:size()
+        size_t size()
+

--- a/tests/test_files/inherited.hpp
+++ b/tests/test_files/inherited.hpp
@@ -1,0 +1,64 @@
+template<typename A>
+class Base
+{
+public:
+    Base<A>() = default;
+    A a = 1;
+    A foo()
+    {
+        return a;
+    }
+};
+
+class BaseZ
+{
+public:
+    BaseZ() = default;
+    int a = 0;
+    // TODO needs different name, otherwise clashes when both are inherited from
+    //  Think about if this can be caught in autowrap
+    int bar()
+    {
+        return a;
+    }
+};
+
+template<typename A>
+class Inherited: public Base<A>, public BaseZ
+{
+public:
+    Inherited<A>(): Base<A>(), BaseZ(){};
+
+    A getBase()
+    {
+        return Base<A>::a;
+    }
+
+    int getBaseZ()
+    {
+        return BaseZ::a;
+    }
+};
+
+template<typename A, typename B>
+class InheritedTwo: public Base<A>, public Base<B>, public BaseZ
+{
+public:
+    InheritedTwo<A,B>(): Base<A>(), Base<B>(), BaseZ(){};
+
+    A getBase()
+    {
+        return Base<A>::a;
+    }
+
+    B getBaseB()
+    {
+        return Base<B>::a;
+    }
+
+    int getBaseZ()
+    {
+        return BaseZ::a;
+    }
+};
+

--- a/tests/test_files/inherited.pxd
+++ b/tests/test_files/inherited.pxd
@@ -2,11 +2,48 @@
 
 cdef extern from "inherited.hpp":
 
-    cdef cppclass Inherited[A]:
+    cdef cppclass Base[A]:
         # wrap-instances:
-        #    InheritedInt[int]
+        #    BaseInt := Base[int]
+        #    BaseDouble := Base[double]
+        Base()
+        A a
+        A foo()
+
+
+    cdef cppclass BaseZ:
+        BaseZ()
+        int a
+        int bar()
+
+    ## TODO we cannot inherit properties/members automatically yet in autowrap (desirable?)
+
+    cdef cppclass Inherited[A](Base[A], BaseZ):
+        # wrap-instances:
+        #    InheritedInt := Inherited[int]
         #
         # wrap-inherits:
         #    Base[A]
-        #    Base0
-        pass
+        #    BaseZ
+        Inherited()
+        A getBase()
+        int getBaseZ()
+
+    ## TODO cannot wrap-inherit from any of Base since there will be a clash of int foo() and double foo()
+    ##  and our calling code does not make a difference from which base class this comes from
+    # def foo(self):
+    #     """Cython signature: int foo()"""
+    #     cdef int _r = self.inst.get().foo()
+    #     py_result = <int>_r
+    #     return py_result
+
+    cdef cppclass InheritedTwo[A,B](Base[A], Base[B], BaseZ):
+        # wrap-instances:
+        #    InheritedIntDbl := InheritedTwo[int,double]
+        #
+        # wrap-inherits:
+        #    BaseZ
+        InheritedTwo()
+        A getBase()
+        B getBaseB()
+        int getBaseZ()

--- a/tests/test_files/inherited.pyx
+++ b/tests/test_files/inherited.pyx
@@ -1,0 +1,203 @@
+#Generated with autowrap 0.22.9 and Cython (Parser) 3.0.0a10
+#cython: c_string_encoding=ascii
+#cython: embedsignature=False
+from  enum             import Enum as _PyEnum
+from cpython cimport Py_buffer
+from  libcpp.string   cimport string as libcpp_string
+from  libcpp.string   cimport string as libcpp_utf8_string
+from  libcpp.string   cimport string as libcpp_utf8_output_string
+from  libcpp.set      cimport set as libcpp_set
+from  libcpp.vector   cimport vector as libcpp_vector
+from  libcpp.pair     cimport pair as libcpp_pair
+from  libcpp.map      cimport map  as libcpp_map
+from  libcpp          cimport bool
+from  libc.string     cimport const_char
+from  cython.operator cimport dereference as deref, preincrement as inc, address as address
+from  AutowrapRefHolder      cimport AutowrapRefHolder
+from  AutowrapPtrHolder      cimport AutowrapPtrHolder
+from  AutowrapConstPtrHolder cimport AutowrapConstPtrHolder
+from  smart_ptr       cimport shared_ptr
+from inherited cimport Base as _Base
+from inherited cimport Base as _Base
+from inherited cimport BaseZ as _BaseZ
+from inherited cimport Inherited as _Inherited
+from inherited cimport InheritedTwo as _InheritedTwo
+
+cdef extern from "autowrap_tools.hpp":
+    char * _cast_const_away(char *) 
+
+cdef class BaseDouble:
+    """
+    Cython implementation of _Base[double]
+    """
+
+    cdef shared_ptr[_Base[double]] inst
+
+    def __dealloc__(self):
+         self.inst.reset()
+
+    
+    property a:
+        def __set__(self, double a):
+        
+            self.inst.get().a = (<double>a)
+        
+    
+        def __get__(self):
+            cdef double _r = self.inst.get().a
+            py_result = <double>_r
+            return py_result
+    
+    def __init__(self):
+        """Cython signature: void BaseDouble()"""
+        self.inst = shared_ptr[_Base[double]](new _Base[double]())
+    
+    def foo(self):
+        """Cython signature: double foo()"""
+        cdef double _r = self.inst.get().foo()
+        py_result = <double>_r
+        return py_result 
+
+cdef class BaseInt:
+    """
+    Cython implementation of _Base[int]
+    """
+
+    cdef shared_ptr[_Base[int]] inst
+
+    def __dealloc__(self):
+         self.inst.reset()
+
+    
+    property a:
+        def __set__(self,  a):
+        
+            self.inst.get().a = (<int>a)
+        
+    
+        def __get__(self):
+            cdef int _r = self.inst.get().a
+            py_result = <int>_r
+            return py_result
+    
+    def __init__(self):
+        """Cython signature: void BaseInt()"""
+        self.inst = shared_ptr[_Base[int]](new _Base[int]())
+    
+    def foo(self):
+        """Cython signature: int foo()"""
+        cdef int _r = self.inst.get().foo()
+        py_result = <int>_r
+        return py_result 
+
+cdef class BaseZ:
+    """
+    Cython implementation of _BaseZ
+    """
+
+    cdef shared_ptr[_BaseZ] inst
+
+    def __dealloc__(self):
+         self.inst.reset()
+
+    
+    property a:
+        def __set__(self,  a):
+        
+            self.inst.get().a = (<int>a)
+        
+    
+        def __get__(self):
+            cdef int _r = self.inst.get().a
+            py_result = <int>_r
+            return py_result
+    
+    def __init__(self):
+        """Cython signature: void BaseZ()"""
+        self.inst = shared_ptr[_BaseZ](new _BaseZ())
+    
+    def bar(self):
+        """Cython signature: int bar()"""
+        cdef int _r = self.inst.get().bar()
+        py_result = <int>_r
+        return py_result 
+
+cdef class InheritedInt:
+    """
+    Cython implementation of _Inherited[int]
+     -- Inherits from ['Base[A]', 'BaseZ']
+    """
+
+    cdef shared_ptr[_Inherited[int]] inst
+
+    def __dealloc__(self):
+         self.inst.reset()
+
+    
+    def __init__(self):
+        """Cython signature: void InheritedInt()"""
+        self.inst = shared_ptr[_Inherited[int]](new _Inherited[int]())
+    
+    def getBase(self):
+        """Cython signature: int getBase()"""
+        cdef int _r = self.inst.get().getBase()
+        py_result = <int>_r
+        return py_result
+    
+    def getBaseZ(self):
+        """Cython signature: int getBaseZ()"""
+        cdef int _r = self.inst.get().getBaseZ()
+        py_result = <int>_r
+        return py_result
+    
+    def foo(self):
+        """Cython signature: int foo()"""
+        cdef int _r = self.inst.get().foo()
+        py_result = <int>_r
+        return py_result
+    
+    def bar(self):
+        """Cython signature: int bar()"""
+        cdef int _r = self.inst.get().bar()
+        py_result = <int>_r
+        return py_result 
+
+cdef class InheritedIntDbl:
+    """
+    Cython implementation of _InheritedTwo[int,double]
+     -- Inherits from ['BaseZ']
+    """
+
+    cdef shared_ptr[_InheritedTwo[int,double]] inst
+
+    def __dealloc__(self):
+         self.inst.reset()
+
+    
+    def __init__(self):
+        """Cython signature: void InheritedIntDbl()"""
+        self.inst = shared_ptr[_InheritedTwo[int,double]](new _InheritedTwo[int,double]())
+    
+    def getBase(self):
+        """Cython signature: int getBase()"""
+        cdef int _r = self.inst.get().getBase()
+        py_result = <int>_r
+        return py_result
+    
+    def getBaseB(self):
+        """Cython signature: double getBaseB()"""
+        cdef double _r = self.inst.get().getBaseB()
+        py_result = <double>_r
+        return py_result
+    
+    def getBaseZ(self):
+        """Cython signature: int getBaseZ()"""
+        cdef int _r = self.inst.get().getBaseZ()
+        py_result = <int>_r
+        return py_result
+    
+    def bar(self):
+        """Cython signature: int bar()"""
+        cdef int _r = self.inst.get().bar()
+        py_result = <int>_r
+        return py_result 

--- a/tests/test_files/minimal.cpp
+++ b/tests/test_files/minimal.cpp
@@ -200,6 +200,15 @@ std::vector<Minimal>::iterator Minimal::end()
     return this->_mi.end();
 }
 
+std::vector<Minimal>::reverse_iterator Minimal::rbegin()
+{
+    return this->_mi.rbegin();
+}
+std::vector<Minimal>::reverse_iterator Minimal::rend()
+{
+    return this->_mi.rend();
+}
+
 long int Minimal::run_static(long int i, bool)
 {
     return i*4;

--- a/tests/test_files/minimal.hpp
+++ b/tests/test_files/minimal.hpp
@@ -103,6 +103,10 @@ class Minimal {
         {
             return Minimal(this->_i * that._i);
         }
+        Minimal operator/(Minimal that)
+        {
+            return Minimal(this->_i / that._i);
+        }
         Minimal operator*=(Minimal that)
         {
             this->_i = this->_i * that._i;

--- a/tests/test_files/minimal.hpp
+++ b/tests/test_files/minimal.hpp
@@ -90,6 +90,10 @@ class Minimal {
         {
             return Minimal(this->_i + that._i);
         }
+        Minimal operator-(Minimal that)
+        {
+            return Minimal(this->_i - that._i);
+        }
         Minimal operator+=(Minimal that)
         {
             this->_i = this->_i + that._i;

--- a/tests/test_files/minimal.hpp
+++ b/tests/test_files/minimal.hpp
@@ -17,6 +17,7 @@ class Minimal {
     public:
 
         static const int m_const = -1;
+        static const int m_constdef = -1;
         int m_accessible;
 
         Minimal();

--- a/tests/test_files/minimal.hpp
+++ b/tests/test_files/minimal.hpp
@@ -74,6 +74,9 @@ class Minimal {
         std::vector<Minimal>::iterator begin();
         std::vector<Minimal>::iterator end();
 
+        std::vector<Minimal>::reverse_iterator rbegin();
+        std::vector<Minimal>::reverse_iterator rend();
+
         Minimal create() const;
 
         Minimal & getRef();

--- a/tests/test_files/minimal.hpp
+++ b/tests/test_files/minimal.hpp
@@ -112,6 +112,16 @@ class Minimal {
             this->_i = this->_i * that._i;
             return *this;
         }
+        Minimal operator-=(Minimal that)
+        {
+            this->_i = this->_i - that._i;
+            return *this;
+        }
+        Minimal operator/=(Minimal that)
+        {
+            this->_i = this->_i / that._i;
+            return *this;
+        }
 
 };
 

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -83,6 +83,7 @@ cdef extern from "minimal.hpp":
         Minimal operator+(Minimal)
         Minimal operator*(Minimal)
         Minimal operator-(Minimal)
+        Minimal operator/(Minimal)
 
         # cython does not support declaration of operator+= yet
         Minimal iadd(Minimal) # wrap-as:operator+=

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -87,6 +87,9 @@ cdef extern from "minimal.hpp":
 
         # cython does not support declaration of operator+= yet
         Minimal iadd(Minimal) # wrap-as:operator+=
+        Minimal isub(Minimal) # wrap-as:operator-=
+        Minimal imul(Minimal) # wrap-as:operator*=
+        Minimal itruediv(Minimal) # wrap-as:operator/=
 
     int top_function(int)
     int sumup(libcpp_vector[int] what)

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -23,6 +23,7 @@ cdef extern from "minimal.hpp":
 
         int m_accessible
         int m_const # wrap-constant
+        const int m_constdef
 
         int get()
         libcpp_string compute(libcpp_string)

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -82,6 +82,8 @@ cdef extern from "minimal.hpp":
 
         Minimal operator+(Minimal)
         Minimal operator*(Minimal)
+        Minimal operator-(Minimal)
+
         # cython does not support declaration of operator+= yet
         Minimal iadd(Minimal) # wrap-as:operator+=
 

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -54,12 +54,15 @@ cdef extern from "minimal.hpp":
         unsigned int test_special_converter(unsigned int)
 
         void setVector(libcpp_vector[Minimal]) # wrap-doc:Sets vector
-        libcpp_vector[Minimal] getVector()# wrap-doc:Gets vector
+        libcpp_vector[Minimal] getVector() # wrap-doc:Gets vector
 
         int test2Lists(const libcpp_vector[Minimal]&, libcpp_vector[int])
 
         libcpp_vector[Minimal].iterator begin() # wrap-iter-begin:__iter__(Minimal)
         libcpp_vector[Minimal].iterator end()   # wrap-iter-end:__iter__(Minimal)
+
+        libcpp_vector[Minimal].reverse_iterator rbegin() # wrap-iter-begin:__reversed__(Minimal)
+        libcpp_vector[Minimal].reverse_iterator rend()   # wrap-iter-end:__reversed__(Minimal)
 
         int operator()(Minimal) # wrap-cast:toInt
 

--- a/tests/test_full_library.py
+++ b/tests/test_full_library.py
@@ -231,7 +231,7 @@ def test_full_lib(tmpdir):
                 manual_code=manual_code,
                 extra_cimports=cimports,
                 include_boost=True,
-                allDecl=masterDict,
+                all_decl=masterDict,
                 add_relative=True
             )
             masterDict[modname]["inc_dirs"] = autowrap_include_dirs


### PR DESCRIPTION
This is a draft of the modifications needed to add support for automatically generating `__getbuffer__` and `__releasebuffer__` logic so that `autowrap`-wrapped objects can implement the [buffer protocol](https://docs.python.org/3/c-api/buffer.html). This isn't finished (no formal tests yet, though I have tested by hand), but I wanted to get feedback on how the directive should be specified. Right now, it's a triplet separated by commas:
```
        # wrap-buffer-protocol:
        #    <expression on self to get the buffer address>,<buffer type>,<expression on self to get buffer size in items>
        #
```
Filled in from the example:
```
        # wrap-buffer-protocol:
        #    data_.data(),float,size()
        #
```
This doesn't feel clean, requiring complex expressions in two places on a single line and relies on a delimiter that could appear in those expressions, ",". It seems like directives spread over multiple lines are separate instructions, but an object can only export a buffer one way, so I might be able to instead split the above into:
```
        # wrap-buffer-protocol:
        #    data_.data()
        #    float
        #    size()
```
This only supports exporting simple buffers of scalars cleanly and only of a single dimension (no strided matrices).

The manual testing on the example amounts to
```python
import py_vec_holder
import numpy as np

holder = py_vec_holder.VecHolder()
holder.add(1.0)
holder.add(2.0)
holder.add(3.0)

view = np.asarray(holder)
assert np.allclose(view, [1.0, 2.0, 3.0])
assert view.base.obj is holder
```
