### PR TITLE
added: wrapper for '/' operator and tests

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -700,7 +700,7 @@ class CodeGenerator(object):
                 return [code], Code.Code()
             elif op == "/":
                 assert len(methods) == 1, "overloaded operator/ not supported"
-                code = self.create_special_div_method(cdcl, methods[0])
+                code = self.create_special_truediv_method(cdcl, methods[0])
                 return [code], Code.Code()
             elif op == "+=":
                 assert len(methods) == 1, "overloaded operator+= not supported"
@@ -1143,7 +1143,7 @@ class CodeGenerator(object):
         """, locals())
         return code
         
-    def create_special_div_method(self, cdcl, mdcl):
+    def create_special_truediv_method(self, cdcl, mdcl):
         L.info("   create wrapper for operator/")
         assert len(mdcl.arguments) == 1, "operator/ has wrong signature"
         (__, t), = mdcl.arguments
@@ -1154,7 +1154,7 @@ class CodeGenerator(object):
         code = Code.Code()
         code.add("""
         |
-        |def __div__($name self, $name other not None):
+        |def __truediv__($name self, $name other not None):
         |    cdef $cy_t  * this = self.inst.get()
         |    cdef $cy_t * that = other.inst.get()
         |    cdef $cy_t divided = deref(this) / deref(that)

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -698,6 +698,10 @@ class CodeGenerator(object):
                 assert len(methods) == 1, "overloaded operator* not supported"
                 code = self.create_special_mul_method(cdcl, methods[0])
                 return [code], Code.Code()
+            elif op == "/":
+                assert len(methods) == 1, "overloaded operator/ not supported"
+                code = self.create_special_div_method(cdcl, methods[0])
+                return [code], Code.Code()
             elif op == "+=":
                 assert len(methods) == 1, "overloaded operator+= not supported"
                 code = self.create_special_iadd_method(cdcl, methods[0])
@@ -1135,6 +1139,27 @@ class CodeGenerator(object):
         |    cdef $cy_t multiplied = deref(this) * deref(that)
         |    cdef $name result = $name.__new__($name)
         |    result.inst = shared_ptr[$cy_t](new $cy_t(multiplied))
+        |    return result
+        """, locals())
+        return code
+        
+    def create_special_div_method(self, cdcl, mdcl):
+        L.info("   create wrapper for operator/")
+        assert len(mdcl.arguments) == 1, "operator/ has wrong signature"
+        (__, t), = mdcl.arguments
+        name = cdcl.name
+        assert t.base_type == name, "can only divide with myself"
+        assert mdcl.result_type.base_type == name, "can only return same type"
+        cy_t = self.cr.cython_type(t)
+        code = Code.Code()
+        code.add("""
+        |
+        |def __div__($name self, $name other not None):
+        |    cdef $cy_t  * this = self.inst.get()
+        |    cdef $cy_t * that = other.inst.get()
+        |    cdef $cy_t divided = deref(this) / deref(that)
+        |    cdef $name result = $name.__new__($name)
+        |    result.inst = shared_ptr[$cy_t](new $cy_t(divided))
         |    return result
         """, locals())
         return code

--- a/tests/test_code_generator_minimal.py
+++ b/tests/test_code_generator_minimal.py
@@ -279,4 +279,11 @@ def test_minimal():
     assert m1 == wrapped.Minimal(9)
     assert m2 == wrapped.Minimal(81)
 
+    # operator div
+    assert wrapped.Minimal(10) / wrapped.Minimal(2) == wrapped.Minimal(5)
+
+    m1 = wrapped.Minimal(3)
+    m1 = m1 / m1
+    assert m1 == wrapped.Minimal(1)
+
 

--- a/tests/test_files/minimal.hpp
+++ b/tests/test_files/minimal.hpp
@@ -103,6 +103,10 @@ class Minimal {
         {
             return Minimal(this->_i * that._i);
         }
+        Minimal operator/(Minimal that)
+        {
+            return Minimal(this->_i / that._i);
+        }
         Minimal operator*=(Minimal that)
         {
             this->_i = this->_i * that._i;

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -83,6 +83,7 @@ cdef extern from "minimal.hpp":
         Minimal operator+(Minimal)
         Minimal operator*(Minimal)
         Minimal operator-(Minimal)
+        Minimal operator/(Minimal)
 
         # cython does not support declaration of operator+= yet
         Minimal iadd(Minimal) # wrap-as:operator+=


### PR DESCRIPTION
Changed these files:
autowrap/CodeGenerator.py
tests/test_code_generator_minimal.py
tests/test_files/minimal.hpp
tests/test_files/minimal.pxd

Kindly test and review

For issue #129