### PR TITLE
Add support for modulus op and iop

### DIFF
--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -1035,6 +1035,12 @@ class CodeGenerator(object):
                     "truediv", "/", cdcl, methods[0]
                 )
                 return [code], stubs
+            elif op == "%":
+                assert len(methods) == 1, "overloaded operator% no supported"
+                code, stubs = self.create_special_op_method(
+                    "mod", "%", cdcl, methods[0]
+                )
+                return [code], stubs
             elif op == "+=":
                 assert len(methods) == 1, "overloaded operator+= not supported"
                 code, stubs = self.create_special_iop_method(
@@ -1057,6 +1063,12 @@ class CodeGenerator(object):
                 assert len(methods) == 1, "overloaded operator/= not supported"
                 code, stubs = self.create_special_iop_method(
                     "itruediv", "/=", cdcl, methods[0]
+                )
+                return [code], stubs
+            elif op == "%=":
+                assert len(methods) == 1, "overloaded operator%= not supported"
+                code, stubs = self.create_special_iop_method(
+                    "imod", "%=", cdcl, methods[0]
                 )
                 return [code], stubs
 

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -1035,6 +1035,18 @@ class CodeGenerator(object):
                     "truediv", "/", cdcl, methods[0]
                 )
                 return [code], stubs
+            elif op == "<<":
+                assert len(methods) == 1, "overloaded operator<< not supported"
+                code, stubs = self.create_special_op_method(
+                    "lshift", "<<", cdcl, methods[0]
+                )
+                return [code], stubs
+            elif op == ">>":
+                assert len(methods) == 1, "overloaded operator>> not supported"
+                code, stubs = self.create_special_op_method(
+                    "rshift", ">>", cdcl, methods[0]
+                )
+                return [code], stubs
             elif op == "%":
                 assert len(methods) == 1, "overloaded operator% no supported"
                 code, stubs = self.create_special_op_method(
@@ -1069,6 +1081,18 @@ class CodeGenerator(object):
                 assert len(methods) == 1, "overloaded operator%= not supported"
                 code, stubs = self.create_special_iop_method(
                     "imod", "%=", cdcl, methods[0]
+                )
+                return [code], stubs
+            elif op == "<<=":
+                assert len(methods) == 1, "overloaded operator<<= not supported"
+                code, stubs = self.create_special_iop_method(
+                    "ilshift", "<<=", cdcl, methods[0]
+                )
+                return [code], stubs
+            elif op == ">>=":
+                assert len(methods) == 1, "overloaded operator>>= not supported"
+                code, stubs = self.create_special_iop_method(
+                    "irshift", ">>=", cdcl, methods[0]
                 )
                 return [code], stubs
 

--- a/autowrap/data_files/autowrap/autowrap_tools.hpp
+++ b/autowrap/data_files/autowrap/autowrap_tools.hpp
@@ -29,6 +29,15 @@ template<class A> void _imod(A * a1, const A * a2)
     (*a1) %= (*a2);
 }
 
+template<class A> void _ilshift(A * a1, const A * a2)
+{
+    (*a1) <<= (*a2);
+}
+
+template<class A> void _irshift(A * a1, const A * a2)
+{
+    (*a1) >>= (*a2);
+}
 namespace autowrap {
 
     template <class X>

--- a/autowrap/data_files/autowrap/autowrap_tools.hpp
+++ b/autowrap/data_files/autowrap/autowrap_tools.hpp
@@ -24,6 +24,11 @@ template<class A> void _itruediv(A * a1, const A * a2)
     (*a1) /= (*a2);
 }
 
+template<class A> void _imod(A * a1, const A * a2)
+{
+    (*a1) %= (*a2);
+}
+
 namespace autowrap {
 
     template <class X>
@@ -35,7 +40,7 @@ namespace autowrap {
 
         public:
 
-            AutowrapRefHolder(X &ref): _ref(ref) 
+            AutowrapRefHolder(X &ref): _ref(ref)
             {
             }
 
@@ -61,7 +66,7 @@ namespace autowrap {
 
             AutowrapPtrHolder() {}
 
-            AutowrapPtrHolder(X *ref): _ptr(ref) 
+            AutowrapPtrHolder(X *ref): _ptr(ref)
             {
             }
 
@@ -87,7 +92,7 @@ namespace autowrap {
 
             AutowrapConstPtrHolder() {}
 
-            AutowrapConstPtrHolder(const X *ref): _ptr(ref) 
+            AutowrapConstPtrHolder(const X *ref): _ptr(ref)
             {
             }
 

--- a/tests/test_code_generator_minimal.py
+++ b/tests/test_code_generator_minimal.py
@@ -297,3 +297,17 @@ def test_minimal():
     m1 = wrapped.Minimal(3)
     m1 /= m1
     assert m1 == wrapped.Minimal(1)
+
+    # operator mod
+    assert wrapped.Minimal(10) % wrapped.Minimal(2) == wrapped.Minimal(0)
+    assert wrapped.Minimal(10) % wrapped.Minimal(3) == wrapped.Minimal(1)
+
+    m1 = wrapped.Minimal(10)
+    m2 = wrapped.Minimal(2)
+    m1 %= m2
+    assert m1 == wrapped.Minimal(0)
+
+    m3 = wrapped.Minimal(11)
+    m4 = wrapped.Minimal(3)
+    m3 %= m4
+    assert m3 == wrapped.Minimal(2)

--- a/tests/test_code_generator_minimal.py
+++ b/tests/test_code_generator_minimal.py
@@ -311,3 +311,19 @@ def test_minimal():
     m4 = wrapped.Minimal(3)
     m3 %= m4
     assert m3 == wrapped.Minimal(2)
+
+    # operator lshift
+    assert wrapped.Minimal(10) << wrapped.Minimal(2) == wrapped.Minimal(40)
+
+    m1 = wrapped.Minimal(10)
+    m2 = wrapped.Minimal(1)
+    m1 <<= m2
+    assert m1 == wrapped.Minimal(20)
+
+    # operator rshift
+    assert wrapped.Minimal(10) >> wrapped.Minimal(2) == wrapped.Minimal(2)
+
+    m1 = wrapped.Minimal(10)
+    m2 = wrapped.Minimal(1)
+    m1 >>= m2
+    assert m1 == wrapped.Minimal(5)

--- a/tests/test_files/minimal.hpp
+++ b/tests/test_files/minimal.hpp
@@ -59,7 +59,7 @@ class Minimal {
             return _mi.size();
         }
 
-        int operator[](const int i) const 
+        int operator[](const int i) const
         {
             return i+1;
         };
@@ -111,6 +111,10 @@ class Minimal {
         {
             return Minimal(this->_i / that._i);
         }
+        Minimal operator%(Minimal that)
+        {
+            return Minimal(this->_i % that._i);
+        }
         Minimal operator*=(Minimal that)
         {
             this->_i = this->_i * that._i;
@@ -124,6 +128,11 @@ class Minimal {
         Minimal operator/=(Minimal that)
         {
             this->_i = this->_i / that._i;
+            return *this;
+        }
+        Minimal operator%=(Minimal that)
+        {
+            this->_i = this->_i % that._i;
             return *this;
         }
 

--- a/tests/test_files/minimal.hpp
+++ b/tests/test_files/minimal.hpp
@@ -115,6 +115,14 @@ class Minimal {
         {
             return Minimal(this->_i % that._i);
         }
+        Minimal operator<<(Minimal that)
+        {
+            return Minimal(this->_i << that._i);
+        }
+        Minimal operator>>(Minimal that)
+        {
+            return Minimal(this->_i >> that._i);
+        }
         Minimal operator*=(Minimal that)
         {
             this->_i = this->_i * that._i;
@@ -133,6 +141,16 @@ class Minimal {
         Minimal operator%=(Minimal that)
         {
             this->_i = this->_i % that._i;
+            return *this;
+        }
+        Minimal operator<<=(Minimal that)
+        {
+            this->_i = this->_i << that._i;
+            return *this;
+        }
+        Minimal operator>>=(Minimal that)
+        {
+            this->_i = this->_i >> that._i;
             return *this;
         }
 

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -89,6 +89,8 @@ cdef extern from "minimal.hpp":
         Minimal operator-(Minimal)
         Minimal operator/(Minimal)
         Minimal operator%(Minimal)
+        Minimal operator<<(Minimal)
+        Minimal operator>>(Minimal)
 
         # cython does not support declaration of operator+= yet
         Minimal iadd(Minimal) # wrap-as:operator+=
@@ -96,6 +98,8 @@ cdef extern from "minimal.hpp":
         Minimal imul(Minimal) # wrap-as:operator*=
         Minimal itruediv(Minimal) # wrap-as:operator/=
         Minimal imod(Minimal) # wrap-as:operator%=
+        Minimal ilshift(Minimal) # wrap-as:operator<<=
+        Minimal irshift(Minimal) # wrap-as:operator>>=
 
     int top_function(int)
     int sumup(libcpp_vector[int] what)

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -88,12 +88,14 @@ cdef extern from "minimal.hpp":
         Minimal operator*(Minimal)
         Minimal operator-(Minimal)
         Minimal operator/(Minimal)
+        Minimal operator%(Minimal)
 
         # cython does not support declaration of operator+= yet
         Minimal iadd(Minimal) # wrap-as:operator+=
         Minimal isub(Minimal) # wrap-as:operator-=
         Minimal imul(Minimal) # wrap-as:operator*=
         Minimal itruediv(Minimal) # wrap-as:operator/=
+        Minimal imod(Minimal) # wrap-as:operator%=
 
     int top_function(int)
     int sumup(libcpp_vector[int] what)


### PR DESCRIPTION
Had to make a new branch, sorry. Original PR was here: https://github.com/OpenMS/autowrap/pull/158

This PR is trying to finish off issue #129. I'll add support for the following operators:
modulus: `%` and `%=`
shift operators: `<<`, `>>`, `<<=`, and `>>=`
~floor division: `//` and `//=`~ Looks like this is already included with regular division?
~exponentiation: `**` ~ there is no exponentiation operator in C++, see [this stack overflow answer](https://stackoverflow.com/a/11211612/11903505) for a pretty good description of why.

Let me know if I should add more stuff.