### PR TITLE
new docstring style for functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ sdist
 develop-eggs
 .installed.cfg
 .idea
+.vscode
 
 # Installer logs
 pip-log.txt

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,7 @@
 # and commit this file to your remote git repository to share the goodness with others.
 
 tasks:
-  - init: pip install .
+  - init: pip install pytest black && pip install -e .
 vscode:
   extensions:
     - ms-python.python

--- a/autowrap/Code.py
+++ b/autowrap/Code.py
@@ -95,11 +95,11 @@ class Code(object):
             if isinstance(content, basestring):
                 result.append(_indent + content)
             else:
-                newindent = _indent + " "*4
+                newindent = _indent + " " * 4
                 for line in content._render(_indent=newindent):
                     result.append(line)
         return result
 
     def render(self, indent=0) -> str:
-        i = " "*indent
+        i = " " * indent
         return "\n".join(self._render(_indent=i))

--- a/autowrap/Code.py
+++ b/autowrap/Code.py
@@ -57,9 +57,16 @@ class Code(object):
     def __init__(self):
         self.content: List[Union[Code, str]] = []
 
+    def __len__(self):
+        return sum(len(c) if isinstance(c, Code) else 1 for c in self.content)
+
     def extend(self, other: Code) -> None:
         # keeps indentation
         self.content.extend(other.content)
+
+    def addRawList(self, lst):
+        # keeps indentation
+        self.content.extend(lst)
 
     def add(self, what: Union[str, bytes, Code], *a, **kw) -> Code:
         # may increase indent!
@@ -88,9 +95,11 @@ class Code(object):
             if isinstance(content, basestring):
                 result.append(_indent + content)
             else:
-                for line in content._render(_indent=_indent + "    "):
+                newindent = _indent + " "*4
+                for line in content._render(_indent=newindent):
                     result.append(line)
         return result
 
-    def render(self) -> str:
-        return "\n".join(self._render())
+    def render(self, indent=0) -> str:
+        i = " "*indent
+        return "\n".join(self._render(_indent=i))

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -934,7 +934,7 @@ class CodeGenerator(object):
 
         docstrings.add("")
 
-        for method, sig in zip(methods,signatures):
+        for method, sig in zip(methods, signatures):
             # Now add Cython signatures with additional description for each overload (if available)
             extra_doc = method.cpp_decl.annotations.get("wrap-doc", None)
             if extra_doc is not None:
@@ -955,7 +955,9 @@ class CodeGenerator(object):
 
         first_iteration = True
 
-        for (dispatched_m_name, method, sig) in zip(dispatched_m_names, methods, signatures):
+        for (dispatched_m_name, method, sig) in zip(
+            dispatched_m_names, methods, signatures
+        ):
             args = augment_arg_names(method)
             return_type = self.cr.get(method.result_type).matching_python_type_full(
                 method.result_type

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -471,9 +471,9 @@ class CodeGenerator(object):
         else:
             name = decl.name
 
-        doc = decl.cpp_decl.annotations.get("wrap-doc", "")
-        if doc:
-            doc = '"""\n    ' + "\n    ".join(doc) + '\n    """'
+        doc = decl.cpp_decl.annotations.get("wrap-doc", None)
+        if doc is not None:
+            doc = '"""\n    ' + doc.render(indent=4) + '\n    """'
 
         L.info("create wrapper for enum %s" % name)
         code = Code()
@@ -543,7 +543,7 @@ class CodeGenerator(object):
                     |
                     |    def getMapping(self):
                     |        return dict([ (v, k) for k, v in self.__class__.__dict__.items()
-                    +if isinstance(v, int) ])"""
+                    + if isinstance(v, int) ])"""
             )
             stub_code.add(
                 """
@@ -604,13 +604,13 @@ class CodeGenerator(object):
         docstring += special_class_doc % locals()
         if r_class.cpp_decl.annotations.get("wrap-inherits", "") != "":
             docstring += (
-                "     -- Inherits from %s\n"
+                "      -- Inherits from %s\n"
                 % r_class.cpp_decl.annotations.get("wrap-inherits", "")
             )
 
-        extra_doc = r_class.cpp_decl.annotations.get("wrap-doc", "")
-        for extra_doc_line in extra_doc:
-            docstring += "\n    " + extra_doc_line
+        extra_doc = r_class.cpp_decl.annotations.get("wrap-doc", None)
+        if extra_doc is not None:
+            docstring += extra_doc.render(indent=4)
 
         self.typestub_codes[cname] = typestub_code
         typestub_code.add(
@@ -906,27 +906,11 @@ class CodeGenerator(object):
         if use_kwargs:
             kwargs = ", **kwargs"
 
-        docstrings = "\n"
+        docstrings = Code()
+        signatures = []
         for method in methods:
-            # Prepare docstring
-            docstrings += " " * 8 + "  - Cython signature: %s" % method
-            extra_doc = method.cpp_decl.annotations.get("wrap-doc", "")
-            if len(extra_doc) > 0:
-                docstrings += "\n" + " " * 12 + extra_doc
-            docstrings += "\n"
-
-        method_code.add(
-            """
-                          |
-                          |def $py_name(self, *args $kwargs):
-                          |    \"\"\"$docstrings\"\"\"
-                        """,
-            locals(),
-        )
-
-        first_iteration = True
-
-        for (dispatched_m_name, method) in zip(dispatched_m_names, methods):
+            ## TODO refactor this part as something like getTypingSignature or getTypingSignatureParts
+            ##  or maybe save them for the after-the-next for-loop that generates them again
             args = augment_arg_names(method)
             py_typing_signature_parts = []
             for arg_num, (t, n) in enumerate(args):
@@ -939,22 +923,63 @@ class CodeGenerator(object):
             )
 
             if return_type:
+                return_type = "-> " + return_type
+            else:
+                return_type = ""
+
+            # Add autodoc docstring signatures first: https://github.com/sphinx-doc/sphinx/pull/7748
+            sig = f"{py_name}(self, {args_typestub_str}) {return_type}"
+            signatures.append(sig)
+            docstrings.add(sig)
+
+        docstrings.add("")
+
+        for method, sig in zip(methods,signatures):
+            # Now add Cython signatures with additional description for each overload (if available)
+            extra_doc = method.cpp_decl.annotations.get("wrap-doc", None)
+            if extra_doc is not None:
+                docstrings.add("- Overload: %s" % sig)
+                docstrings.add(extra_doc)
+            docstrings.add("")
+
+        docstring_as_str = docstrings.render(indent=8)
+        method_code.add(
+            """
+                          |
+                          |def $py_name(self, *args $kwargs):
+                          |    \"\"\"\n$docstring_as_str
+                          |    \"\"\"
+                        """,
+            locals(),
+        )
+
+        first_iteration = True
+
+        for (dispatched_m_name, method, sig) in zip(dispatched_m_names, methods, signatures):
+            args = augment_arg_names(method)
+            return_type = self.cr.get(method.result_type).matching_python_type_full(
+                method.result_type
+            )
+
+            if return_type:
                 return_type = "-> " + return_type + ":"
             else:
                 return_type = ":"
 
-            # Prepare docstring for typestubs (TODO only prepare once?)
+            # Prepare docstring for typestubs
             docstring = "Cython signature: %s" % method
-            extra_doc = method.cpp_decl.annotations.get("wrap-doc", "")
-            if len(extra_doc) > 0:
-                docstring += "\n" + " " * 8 + extra_doc
+            extra_doc = method.cpp_decl.annotations.get("wrap-doc", None)
+            if extra_doc is not None:
+                docstring += "\n" + extra_doc.render(indent=8)
 
             typestub_code.add(
                 """
                           |
                           |@overload
-                          |def $py_name(self, $args_typestub_str) $return_type
-                          |    \"\"\"$docstring\"\"\"
+                          |def $sig:
+                          |    \"\"\"
+                          |    $docstring
+                          |    \"\"\"
                           |    ...
                         """,
                 locals(),
@@ -1163,21 +1188,34 @@ class CodeGenerator(object):
             py_signature_parts.insert(0, "self")
             py_typing_signature_parts.insert(0, "self")
 
-        # Prepare docstring
-        docstring = "Cython signature: %s" % method
-        extra_doc = method.cpp_decl.annotations.get("wrap-doc", "")
-        if len(extra_doc) > 0:
-            docstring += "\n" + " " * 8 + extra_doc
-
         py_signature = ", ".join(py_signature_parts)
         py_typing_signature = ", ".join(py_typing_signature_parts)
+        return_type = self.cr.get(method.result_type).matching_python_type_full(
+            method.result_type
+        )
+        if return_type:
+            return_type = "-> " + return_type
+        else:
+            return_type = ""
+
+        # Prepare docstring
+        docstring = f"{py_name}({py_typing_signature}) {return_type}"
+        stubdocstring = "Cython signature: %s" % method
+
+        extra_doc = method.cpp_decl.annotations.get("wrap-doc", None)
+        if extra_doc is not None:
+            docstring += "\n" + extra_doc.render(indent=8)
+            stubdocstring += "\n" + extra_doc.render(indent=8)
+
         if method.is_static:
             code.add(
                 """
                        |
                        |@staticmethod
                        |def $py_name($py_signature):
-                       |    \"\"\"$docstring\"\"\"
+                       |    \"\"\"
+                       |    $docstring
+                       |    \"\"\"
                        """,
                 locals(),
             )
@@ -1186,28 +1224,24 @@ class CodeGenerator(object):
                 """
                        |
                        |def $py_name($py_signature):
-                       |    \"\"\"$docstring\"\"\"
+                       |    \"\"\"
+                       |    $docstring
+                       |    \"\"\"
                        """,
                 locals(),
             )
 
         stub = Code()
 
-        return_type = self.cr.get(method.result_type).matching_python_type_full(
-            method.result_type
-        )
-        if return_type:
-            return_type = "-> " + return_type + ":"
-        else:
-            return_type = ":"
-
         if method.is_static:
             stub.add(
                 """
                        |
                        |@staticmethod
-                       |def $py_name($py_typing_signature) $return_type
-                       |    \"\"\"$docstring\"\"\"
+                       |def $py_name($py_typing_signature) $return_type:
+                       |    \"\"\"
+                       |    $stubdocstring
+                       |    \"\"\"
                        |    ...
                        """,
                 locals(),
@@ -1216,8 +1250,10 @@ class CodeGenerator(object):
             stub.add(
                 """
                        |
-                       |def $py_name($py_typing_signature) $return_type
-                       |    \"\"\"$docstring\"\"\"
+                       |def $py_name($py_typing_signature) $return_type:
+                       |    \"\"\"
+                       |    $stubdocstring
+                       |    \"\"\"
                        |    ...
                        """,
                 locals(),
@@ -1793,9 +1829,9 @@ class CodeGenerator(object):
 
         # Prepare docstring
         docstring = "Cython signature: %s" % mdcl
-        extra_doc = mdcl.cpp_decl.annotations.get("wrap-doc", "")
-        if len(extra_doc) > 0:
-            docstring += "\n" + " " * 8 + extra_doc
+        extra_doc = mdcl.cpp_decl.annotations.get("wrap-doc", None)
+        if extra_doc is not None:
+            docstring += "\n" + extra_doc.render(indent=8)
 
         stub_code.add(
             """

--- a/autowrap/PXDParser.py
+++ b/autowrap/PXDParser.py
@@ -105,7 +105,9 @@ def _parse_multiline_annotations(lines: Collection[str]) -> AnnotDict:
                     else:
                         value = line[1:].strip()
 
-                    if (key == "wrap-doc" or value):  # don't add empty non wrap-doc values
+                    if (
+                        key == "wrap-doc" or value
+                    ):  # don't add empty non wrap-doc values
                         result[key].append(value)
 
                     try:
@@ -123,7 +125,7 @@ def _parse_multiline_annotations(lines: Collection[str]) -> AnnotDict:
         doc = result.get("wrap-doc", [])
         if isinstance(doc, basestring):
             doc = [doc]
-        
+
         c = Code()
         c.addRawList(doc)
         result["wrap-doc"] = c
@@ -188,7 +190,7 @@ def parse_line_annotations(
             doc = result.get("wrap-doc", [])
             if isinstance(doc, basestring):
                 doc = [doc]
-            
+
             c = Code()
             c.addRawList(doc)
             result["wrap-doc"] = c

--- a/autowrap/PXDParser.py
+++ b/autowrap/PXDParser.py
@@ -50,6 +50,7 @@ from autowrap.Types import CppType
 import os
 
 from autowrap import logger
+from autowrap.Code import Code as Code
 
 from collections import defaultdict
 from .tools import OrderKeepingDictionary
@@ -103,10 +104,10 @@ def _parse_multiline_annotations(lines: Collection[str]) -> AnnotDict:
                         value = line[3:].rstrip()  # rstrip to keep indentation in docs
                     else:
                         value = line[1:].strip()
-                    if (
-                        key == "wrap-doc" or value
-                    ):  # don't add empty non wrap-doc values
+
+                    if (key == "wrap-doc" or value):  # don't add empty non wrap-doc values
                         result[key].append(value)
+
                     try:
                         line = next(it).lstrip()  # lstrip to keep empty lines in docs
                     except StopIteration:
@@ -116,6 +117,16 @@ def _parse_multiline_annotations(lines: Collection[str]) -> AnnotDict:
                 result[key] = True
         else:
             break
+
+    # make sure wrap-doc is always a Code object
+    if "wrap-doc" in result.keys():
+        doc = result.get("wrap-doc", [])
+        if isinstance(doc, basestring):
+            doc = [doc]
+        
+        c = Code()
+        c.addRawList(doc)
+        result["wrap-doc"] = c
     return result
 
 
@@ -166,13 +177,21 @@ def parse_line_annotations(
                         result[key] += value
         except Exception as e:
             raise ValueError("Cannot parse '{}'".format(line)) from e
-
     # check for multi line annotations after method declaration
     additional_annotations = _parse_multiline_annotations(lines[end:])
     # add multi line doc string to result (overwrites single line wrap-doc, if exists)
     if "wrap-doc" in additional_annotations.keys():
-        result["wrap-doc"] = "\n" + "\n".join(additional_annotations["wrap-doc"])
-
+        result["wrap-doc"] = additional_annotations["wrap-doc"]
+    else:
+        # make sure wrap-doc is always a Code object
+        if "wrap-doc" in result.keys():
+            doc = result.get("wrap-doc", [])
+            if isinstance(doc, basestring):
+                doc = [doc]
+            
+            c = Code()
+            c.addRawList(doc)
+            result["wrap-doc"] = c
     return result
 
 

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -57,6 +57,7 @@ def test():
     c.add(inner)
 
     result = c.render()
+    assert len(c) == 5
     lines = [line.rstrip() for line in result.split("\n")]
     assert lines[0] == "def fun(x):", repr(lines[0])
     assert lines[1] == "    if x == 3:", repr(lines[1])

--- a/tests/test_code_generator_libcpp.py
+++ b/tests/test_code_generator_libcpp.py
@@ -111,7 +111,7 @@ def test_libcpp():
     assert len(libcpp.LibCppTest.__doc__) == 213
     assert len(libcpp.LibCppTest.twist.__doc__) == 111
     assert len(libcpp.LibCppTest.gett.__doc__) == 72
-    assert len(libcpp.ABS_Impl1.__doc__) == 89
+    assert len(libcpp.ABS_Impl1.__doc__) == 90
 
     sub_libcpp_copy_constructors(libcpp)
 

--- a/tests/test_code_generator_libcpp.py
+++ b/tests/test_code_generator_libcpp.py
@@ -109,7 +109,7 @@ def test_libcpp():
     assert libcpp.__name__ == "libcpp"
     print(dir(libcpp))
     assert len(libcpp.LibCppTest.__doc__) == 213
-    assert len(libcpp.LibCppTest.twist.__doc__) == 124
+    assert len(libcpp.LibCppTest.twist.__doc__) == 111
     assert len(libcpp.LibCppTest.gett.__doc__) == 66
     assert len(libcpp.ABS_Impl1.__doc__) == 89
 

--- a/tests/test_code_generator_libcpp.py
+++ b/tests/test_code_generator_libcpp.py
@@ -108,7 +108,7 @@ def test_libcpp():
     )
     assert libcpp.__name__ == "libcpp"
     print(dir(libcpp))
-    assert len(libcpp.LibCppTest.__doc__) == 214
+    assert len(libcpp.LibCppTest.__doc__) == 213
     assert len(libcpp.LibCppTest.twist.__doc__) == 124
     assert len(libcpp.LibCppTest.gett.__doc__) == 66
     assert len(libcpp.ABS_Impl1.__doc__) == 89

--- a/tests/test_code_generator_libcpp.py
+++ b/tests/test_code_generator_libcpp.py
@@ -110,7 +110,7 @@ def test_libcpp():
     print(dir(libcpp))
     assert len(libcpp.LibCppTest.__doc__) == 213
     assert len(libcpp.LibCppTest.twist.__doc__) == 111
-    assert len(libcpp.LibCppTest.gett.__doc__) == 66
+    assert len(libcpp.LibCppTest.gett.__doc__) == 72
     assert len(libcpp.ABS_Impl1.__doc__) == 89
 
     sub_libcpp_copy_constructors(libcpp)

--- a/tests/test_code_generator_minimal.py
+++ b/tests/test_code_generator_minimal.py
@@ -95,7 +95,7 @@ def test_minimal():
 
     assert len(minimal.compute.__doc__) == 536
 
-    assert len(minimal.run.__doc__) == 111
+    assert len(minimal.run.__doc__) == 143
 
     # test members
     assert minimal.m_accessible == 0

--- a/tests/test_code_generator_minimal.py
+++ b/tests/test_code_generator_minimal.py
@@ -93,7 +93,7 @@ def test_minimal():
 
     minimal = wrapped.Minimal()
 
-    assert len(minimal.compute.__doc__) == 297
+    assert len(minimal.compute.__doc__) == 536
 
     assert len(minimal.run.__doc__) == 111
 

--- a/tests/test_files/inherited.pyx
+++ b/tests/test_files/inherited.pyx
@@ -1,4 +1,4 @@
-#Generated with autowrap 0.22.9 and Cython (Parser) 3.0.0a10
+#Generated with autowrap 0.22.9 and Cython (Parser) 0.29.32
 #cython: c_string_encoding=ascii
 #cython: embedsignature=False
 from  enum             import Enum as _PyEnum
@@ -49,11 +49,15 @@ cdef class BaseDouble:
             return py_result
     
     def __init__(self):
-        """Cython signature: void BaseDouble()"""
+        """
+        __init__(self) -> None
+        """
         self.inst = shared_ptr[_Base[double]](new _Base[double]())
     
     def foo(self):
-        """Cython signature: double foo()"""
+        """
+        foo(self) -> float
+        """
         cdef double _r = self.inst.get().foo()
         py_result = <double>_r
         return py_result 
@@ -81,11 +85,15 @@ cdef class BaseInt:
             return py_result
     
     def __init__(self):
-        """Cython signature: void BaseInt()"""
+        """
+        __init__(self) -> None
+        """
         self.inst = shared_ptr[_Base[int]](new _Base[int]())
     
     def foo(self):
-        """Cython signature: int foo()"""
+        """
+        foo(self) -> int
+        """
         cdef int _r = self.inst.get().foo()
         py_result = <int>_r
         return py_result 
@@ -113,11 +121,15 @@ cdef class BaseZ:
             return py_result
     
     def __init__(self):
-        """Cython signature: void BaseZ()"""
+        """
+        __init__(self) -> None
+        """
         self.inst = shared_ptr[_BaseZ](new _BaseZ())
     
     def bar(self):
-        """Cython signature: int bar()"""
+        """
+        bar(self) -> int
+        """
         cdef int _r = self.inst.get().bar()
         py_result = <int>_r
         return py_result 
@@ -125,7 +137,7 @@ cdef class BaseZ:
 cdef class InheritedInt:
     """
     Cython implementation of _Inherited[int]
-     -- Inherits from ['Base[A]', 'BaseZ']
+      -- Inherits from ['Base[A]', 'BaseZ']
     """
 
     cdef shared_ptr[_Inherited[int]] inst
@@ -135,29 +147,39 @@ cdef class InheritedInt:
 
     
     def __init__(self):
-        """Cython signature: void InheritedInt()"""
+        """
+        __init__(self) -> None
+        """
         self.inst = shared_ptr[_Inherited[int]](new _Inherited[int]())
     
     def getBase(self):
-        """Cython signature: int getBase()"""
+        """
+        getBase(self) -> int
+        """
         cdef int _r = self.inst.get().getBase()
         py_result = <int>_r
         return py_result
     
     def getBaseZ(self):
-        """Cython signature: int getBaseZ()"""
+        """
+        getBaseZ(self) -> int
+        """
         cdef int _r = self.inst.get().getBaseZ()
         py_result = <int>_r
         return py_result
     
     def foo(self):
-        """Cython signature: int foo()"""
+        """
+        foo(self) -> int
+        """
         cdef int _r = self.inst.get().foo()
         py_result = <int>_r
         return py_result
     
     def bar(self):
-        """Cython signature: int bar()"""
+        """
+        bar(self) -> int
+        """
         cdef int _r = self.inst.get().bar()
         py_result = <int>_r
         return py_result 
@@ -165,7 +187,7 @@ cdef class InheritedInt:
 cdef class InheritedIntDbl:
     """
     Cython implementation of _InheritedTwo[int,double]
-     -- Inherits from ['BaseZ']
+      -- Inherits from ['BaseZ']
     """
 
     cdef shared_ptr[_InheritedTwo[int,double]] inst
@@ -175,29 +197,39 @@ cdef class InheritedIntDbl:
 
     
     def __init__(self):
-        """Cython signature: void InheritedIntDbl()"""
+        """
+        __init__(self) -> None
+        """
         self.inst = shared_ptr[_InheritedTwo[int,double]](new _InheritedTwo[int,double]())
     
     def getBase(self):
-        """Cython signature: int getBase()"""
+        """
+        getBase(self) -> int
+        """
         cdef int _r = self.inst.get().getBase()
         py_result = <int>_r
         return py_result
     
     def getBaseB(self):
-        """Cython signature: double getBaseB()"""
+        """
+        getBaseB(self) -> float
+        """
         cdef double _r = self.inst.get().getBaseB()
         py_result = <double>_r
         return py_result
     
     def getBaseZ(self):
-        """Cython signature: int getBaseZ()"""
+        """
+        getBaseZ(self) -> int
+        """
         cdef int _r = self.inst.get().getBaseZ()
         py_result = <int>_r
         return py_result
     
     def bar(self):
-        """Cython signature: int bar()"""
+        """
+        bar(self) -> int
+        """
         cdef int _r = self.inst.get().bar()
         py_result = <int>_r
         return py_result 

--- a/tests/test_files/minimal.pxd
+++ b/tests/test_files/minimal.pxd
@@ -29,6 +29,11 @@ cdef extern from "minimal.hpp":
         libcpp_string compute(libcpp_string)
         Int compute(int number1, int number2) # wrap-doc:This method is essential for foobar
         int compute(Int number)
+        # wrap-doc:
+        #  Test for Multiline Comment in overloaded method
+        #    with indentation
+        #  
+        #  and empty line
         float compute(float number)
         int compute_int(int)
         int compute_int()

--- a/tests/test_pxd_parser.py
+++ b/tests/test_pxd_parser.py
@@ -560,6 +560,6 @@ def test_multiline_docs():
     lines = ["# wrap-doc:", "#  first line", "#    second line indented", "#  "]
     result = autowrap.PXDParser._parse_multiline_annotations(lines)
 
-    assert result["wrap-doc"][0] == "first line"
-    assert result["wrap-doc"][1] == "  second line indented"
-    assert result["wrap-doc"][2] == ""
+    assert result["wrap-doc"].content[0] == "first line"
+    assert result["wrap-doc"].content[1] == "  second line indented"
+    assert result["wrap-doc"].content[2] == ""


### PR DESCRIPTION
Instead of:

```python
def foo(**args):
"""
   - Cython implementation: Foobar foo(const bar&, baz)
bla from wrapdoc
more bla
   - Cython implementation: Foobaz foo(const bar&)
"""
```

we now have:

```python
def foo(**args):
"""
   foo(bar: int, baz: Union[str, String]) -> Foobar
   foo(bar: int) -> Foobaz

   - Overload: foo(bar: int, baz: Union[str, String]) -> Foobar
       bla from wrapdoc
       more bla

"""
```
where the first typed overloads should be readable by sphinx. See https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_docstring_signature


The Cython implementation is still written into the typestubs, which contain the overload decorator and therefore can be
documented separately.
Unfortunately, no doc tool in the whole wide world supports typestubs and `@overload` at the same time. 
