### PR TITLE
Added some at least basic logging to parsing multi-line comments, so …

### DIFF
--- a/tests/test_files/inherited.pyx
+++ b/tests/test_files/inherited.pyx
@@ -1,8 +1,9 @@
-#Generated with autowrap 0.22.10 and Cython (Parser) 0.29.32
+#Generated with autowrap 0.22.12 and Cython (Parser) 3.1.0
 #cython: c_string_encoding=ascii
 #cython: embedsignature=False
-from  enum             import Enum as _PyEnum
-from cpython cimport Py_buffer
+from  enum            import Enum as _PyEnum
+from  cpython         cimport Py_buffer
+from  cpython         cimport bool as pybool_t
 from  libcpp.string   cimport string as libcpp_string
 from  libcpp.string   cimport string as libcpp_utf8_string
 from  libcpp.string   cimport string as libcpp_utf8_output_string


### PR DESCRIPTION
…it's not hide and seek for which of our thousands of pxds had an error