### PR TITLE
Remove long support

### DIFF
--- a/.github/workflows/ci-autowrap.yaml
+++ b/.github/workflows/ci-autowrap.yaml
@@ -31,6 +31,8 @@ jobs:
             python-version: "3.11"
           - CYTHON: "==3.1.0"
             python-version: "3.12"
+          - CYTHON: "==3.1.0"
+            python-version: "3.13"
     steps:
       - uses: actions/checkout@v4
 

--- a/autowrap/CodeGenerator.py
+++ b/autowrap/CodeGenerator.py
@@ -1652,7 +1652,7 @@ class CodeGenerator(object):
 
         meth_code.add(
             """
-                     |    cdef long _idx = $call_arg
+                     |    cdef int _idx = $call_arg
                      """,
             locals(),
         )
@@ -1754,7 +1754,7 @@ class CodeGenerator(object):
                      |    \"\"\"$docstring\"\"\"
                      |    assert isinstance(key, int), 'arg index wrong type'
                      |
-                     |    cdef long _idx = $call_arg
+                     |    cdef int _idx = $call_arg
                      |    if _idx < 0:
                      |        raise IndexError("invalid index %d" % _idx)
                      """,

--- a/autowrap/ConversionProvider.py
+++ b/autowrap/ConversionProvider.py
@@ -194,20 +194,16 @@ class VoidConverter(TypeConverterBase):
 
 class IntegerConverter(TypeConverterBase):
     """
-    wraps long and int. "long" base_type is converted to "int" by the
-    cython parser!
-    TODO Long does not exist in Python2 anymore. Can we remove stuff?
+    wraps int.
     """
 
     def get_base_types(self) -> List[str]:
         return [
             "int",
             "bint",  # C boolean type
-            "long",
             "int32_t",
             "ptrdiff_t",
             "int64_t",
-            "long int",
             "uint32_t",
             "uint64_t",
             "size_t",
@@ -217,7 +213,7 @@ class IntegerConverter(TypeConverterBase):
         return not cpp_type.is_ptr
 
     def matching_python_type(self, cpp_type: CppType) -> str:
-        return ""  # TODO can't we use int? Especially in py3 only.
+        return "int"
 
     def matching_python_type_full(self, cpp_type: CppType) -> str:
         return "int"
@@ -274,14 +270,12 @@ class BooleanConverter(TypeConverterBase):
 
 class UnsignedIntegerConverter(TypeConverterBase):
     """
-    wraps unsigned long and int. "long" base_type is converted to "int" by the
-    cython parser!
+    wraps unsigned int.
     """
 
     def get_base_types(self) -> List[str]:
         return [
             "unsigned int",
-            "unsigned long",
             "ptrdiff_t",
             "uint32_t",
             "uint64_t",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Code Generators",
 ]
 requires-python = ">=3.9"

--- a/tests/test_files/inherited.pyx
+++ b/tests/test_files/inherited.pyx
@@ -75,7 +75,7 @@ cdef class BaseInt:
 
     
     property a:
-        def __set__(self,  a):
+        def __set__(self, int a):
         
             self.inst.get().a = (<int>a)
         
@@ -111,7 +111,7 @@ cdef class BaseZ:
 
     
     property a:
-        def __set__(self,  a):
+        def __set__(self, int a):
         
             self.inst.get().a = (<int>a)
         


### PR DESCRIPTION
As of Cython 3.1 both longs and integers get put in pylongs (https://github.com/cython/cython/pull/5353) remove the py2 distinction between the types in our CodeGenerator and ConversionProvider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal handling and documentation to remove support for legacy "long" and "unsigned long" integer types, clarifying that only "int" and "unsigned int" are now wrapped.
  * Improved Python type mapping for integer conversions.
  * Added explicit type annotations for certain setter methods to enforce integer input.
* **Chores**
  * Added support for Python 3.13 in testing workflows and project metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->