### PR TITLE
Compatibility with PEP-639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools >= 77.0.3", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,6 +8,7 @@ dynamic = ["version"]
 description = "Generates Python Extension modules from commented Cython PXD files"
 readme = "README.md"
 license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 authors = [
     {name = "OpenMS Inc.", email = "webmaster@openms.de"}
 ]


### PR DESCRIPTION
PEP-639 requires:

  - `setuptools` >= 77.0.3

  - Two keys under the `project` group (`license` and `license-file`)

More details here:

  https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Increased minimum setuptools version to 77.0.3 for building and installation.
  - Ensured the LICENSE file is included in distributed packages.
- Style
  - Minor formatting cleanup (trailing newline); no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->